### PR TITLE
Disallow if_succeeds annotation for contract definitions

### DIFF
--- a/src/bin/scribble.ts
+++ b/src/bin/scribble.ts
@@ -264,6 +264,9 @@ function instrumentFiles(
         assert(contents !== undefined, `Missing source for ${unit.absolutePath}`);
 
         for (const fun of unit.vFunctions) {
+            /**
+             * We call `getAnnotationsOrDie()` here to make sure there are no annotations on free functions.
+             */
             getAnnotationsOrDie(fun, ctx.files, filters);
         }
 

--- a/src/bin/scribble.ts
+++ b/src/bin/scribble.ts
@@ -206,6 +206,12 @@ function computeContractInvs(
                 error(`Unsupported contract annotations on ${contract.kind} ${contract.name}`);
             }
 
+            if (annotations.some((annotation) => annotation.type === AnnotationType.IfSucceeds)) {
+                error(
+                    `Annotation type "${AnnotationType.IfSucceeds}" is not applicable to contracts (specified for ${contract.kind} ${contract.name})`
+                );
+            }
+
             contractAnnotMap.set(contract, annotations);
         }
     });

--- a/src/bin/scribble.ts
+++ b/src/bin/scribble.ts
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import fse from "fs-extra";
+import path, { dirname, relative } from "path";
 import {
     ASTContext,
     ASTNodeFactory,
@@ -21,14 +23,12 @@ import {
     UserDefinedTypeName,
     VariableDeclaration
 } from "solc-typed-ast";
-import fse from "fs-extra";
-import path, { dirname, relative } from "path";
 import { print, rewriteImports } from "../ast_to_source_printer";
 import {
     Annotation,
     AnnotationExtractor,
-    AnnotationType,
-    SyntaxError
+    SyntaxError,
+    UnsupportedByTargetError
 } from "../instrumenter/annotations";
 import { getCallGraph } from "../instrumenter/callgraph";
 import { CHA, chaDFS, getCHA } from "../instrumenter/cha";
@@ -95,17 +95,18 @@ function prettyError(
 function getAnnotationsOrDie(
     node: ContractDefinition | FunctionDefinition,
     sources: Map<string, string>,
-    filterOptions: AnnotationFilterOptions
+    filters: AnnotationFilterOptions
 ): Annotation[] {
     try {
         const extractor = new AnnotationExtractor();
+        const annotations = extractor.extract(node, sources, filters);
 
-        return extractor.extract(node, sources, filterOptions);
+        return annotations;
     } catch (e) {
-        if (e instanceof SyntaxError) {
+        if (e instanceof SyntaxError || e instanceof UnsupportedByTargetError) {
             const unit = getScopeUnit(node);
 
-            prettyError("SyntaxError", e.message, unit, e.range.start, e.annotation);
+            prettyError(e.constructor.name, e.message, unit, e.range.start, e.annotation);
         }
 
         throw e;
@@ -202,16 +203,6 @@ function computeContractInvs(
         const annotations = getAnnotationsOrDie(contract, files, filterOptions);
 
         if (annotations.length > 0) {
-            if ([ContractKind.Interface, ContractKind.Library].includes(contract.kind)) {
-                error(`Unsupported contract annotations on ${contract.kind} ${contract.name}`);
-            }
-
-            if (annotations.some((annotation) => annotation.type === AnnotationType.IfSucceeds)) {
-                error(
-                    `Annotation type "${AnnotationType.IfSucceeds}" is not applicable to contracts (specified for ${contract.kind} ${contract.name})`
-                );
-            }
-
             contractAnnotMap.set(contract, annotations);
         }
     });
@@ -258,7 +249,7 @@ function instrumentFiles(
     contractsNeedingInstr: Set<ContractDefinition>
 ): [SourceUnit[], SourceUnit[]] {
     const units = ctx.units;
-    const filterOptions = ctx.filterOptions;
+    const filters = ctx.filterOptions;
 
     const worklist: Array<[ContractDefinition, FunctionDefinition | undefined, Annotation[]]> = [];
     const typing: TypeMap = new Map();
@@ -273,25 +264,14 @@ function instrumentFiles(
         assert(contents !== undefined, `Missing source for ${unit.absolutePath}`);
 
         for (const fun of unit.vFunctions) {
-            const annotations = getAnnotationsOrDie(fun, ctx.files, filterOptions);
-
-            if (annotations.length > 0) {
-                const annotation = annotations[0];
-
-                prettyError(
-                    "UnsupportedError",
-                    "Instrumenting free functions is not supported yet",
-                    unit,
-                    annotation.predicateFileLoc(contents),
-                    annotation.original
-                );
-            }
+            getAnnotationsOrDie(fun, ctx.files, filters);
         }
 
         for (const contract of unit.vContracts) {
             const typeCtx: STypingCtx = [units, contract];
 
             let contractAnnot = contractInvMap.get(contract);
+
             if (contractAnnot === undefined) {
                 contractAnnot = [];
             }
@@ -324,11 +304,9 @@ function instrumentFiles(
                 }
 
                 const typeCtx: STypingCtx = [units, contract, fun];
-                const funAnnot = getAnnotationsOrDie(fun, ctx.files, filterOptions);
+                const annotations = getAnnotationsOrDie(fun, ctx.files, filters);
 
-                const ifSucceeds = funAnnot.filter((x) => x.type === AnnotationType.IfSucceeds);
-
-                for (const annot of ifSucceeds) {
+                for (const annot of annotations) {
                     tcOrDie(annot, typeCtx, typing, semInfo, fun, contract, contents);
                 }
 
@@ -340,7 +318,7 @@ function instrumentFiles(
                  * Note: Constructors are instrumented in instrumentContract, not by instrumentFunction. fallback() and receive() don't check state invariants.
                  */
                 if (
-                    ifSucceeds.length > 0 ||
+                    annotations.length > 0 ||
                     (needsContrInstr &&
                         isExternallyVisible(fun) &&
                         isChangingState(fun) &&
@@ -349,8 +327,8 @@ function instrumentFiles(
                 ) {
                     changed = true;
 
-                    worklist.push([contract, fun, ifSucceeds]);
-                    ctx.annotations.push(...ifSucceeds);
+                    worklist.push([contract, fun, annotations]);
+                    ctx.annotations.push(...annotations);
                 }
             }
         }

--- a/src/instrumenter/annotations.ts
+++ b/src/instrumenter/annotations.ts
@@ -273,7 +273,7 @@ export class AnnotationExtractor {
         if (target instanceof ContractDefinition) {
             if (annotation.type !== AnnotationType.Invariant) {
                 throw new UnsupportedByTargetError(
-                    `Annotation type "${annotation.type}" is not applicable to a target`,
+                    `The "${annotation.type}" annotation is not applicable to contracts`,
                     annotation.original,
                     annotation.annotationFileLoc(source)
                 );
@@ -289,7 +289,7 @@ export class AnnotationExtractor {
         } else if (target instanceof FunctionDefinition) {
             if (annotation.type !== AnnotationType.IfSucceeds) {
                 throw new UnsupportedByTargetError(
-                    `Annotation type "${annotation.type}" is not applicable to a target`,
+                    `The "${annotation.type}" annotation is not applicable to functions`,
                     annotation.original,
                     annotation.annotationFileLoc(source)
                 );

--- a/src/instrumenter/annotations.ts
+++ b/src/instrumenter/annotations.ts
@@ -1,5 +1,6 @@
 import {
     ContractDefinition,
+    ContractKind,
     FunctionDefinition,
     resolve,
     SourceUnit,
@@ -112,12 +113,23 @@ export class Annotation {
         this.commentLoc = commentLoc;
     }
 
-    /// Get the line/column location of the predicate. (relative to the begining of the file)
+    /**
+     * Get the line/column location of the predicate (relative to the begining of the file)
+     */
     predicateFileLoc(source: string): Range {
         return rangeToLocRange(this.exprLoc[0], this.exprLoc[1], source);
     }
 
-    /// Convert a location relative to the predicate into a file-wide location
+    /**
+     * Get the line/column location of the whole annotation (relative to the begining of the file).
+     */
+    annotationFileLoc(source: string): Range {
+        return rangeToLocRange(this.annotationLoc[0], this.annotationLoc[1], source);
+    }
+
+    /**
+     * Convert a location relative to the predicate into a file-wide location
+     */
     predOffToFileLoc(arg: OffsetRange, source: string): Range {
         const fileOff = offsetBy(arg, this.exprLoc);
 
@@ -125,7 +137,7 @@ export class Annotation {
     }
 }
 
-export class SyntaxError extends Error {
+export class AnnotationError extends Error {
     readonly annotation: string;
     readonly range: Range;
 
@@ -137,161 +149,210 @@ export class SyntaxError extends Error {
     }
 }
 
+export class SyntaxError extends AnnotationError {}
+export class UnsupportedByTargetError extends AnnotationError {}
+
+type RawMetaData = {
+    target: AnnotationTarget;
+    node: StructuredDocumentation;
+    text: string;
+    loc: OffsetRange;
+};
+
 export class AnnotationExtractor {
+    private makeAnnotationFromMatch(
+        match: RegExpExecArray,
+        meta: RawMetaData,
+        source: string
+    ): Annotation {
+        let annotationType: AnnotationType;
+        let annotationLabel: string;
+        let annotationOrig: string;
+        let exprOrig: string;
+        let exprRange: Range;
+        let hasSemi: boolean;
+        let annotationLocRelToRegex: Range;
+
+        try {
+            [
+                annotationType,
+                annotationLabel,
+                annotationOrig,
+                annotationLocRelToRegex,
+                exprOrig,
+                exprRange,
+                hasSemi
+            ] = parseAnnotation(meta.text.slice(match.index));
+        } catch (e) {
+            if (e instanceof AnnotationPEGSSyntaxError) {
+                // Compute the syntax error offset relative to the start of the file
+                const [errStartOff, errLength] = offsetBy(
+                    offsetBy([e.location.start.offset, e.location.end.offset], match.index),
+                    meta.loc
+                );
+
+                const errRange = rangeToLocRange(errStartOff, errLength, source);
+                const original = meta.text.slice(
+                    match.index,
+                    match.index + errStartOff + errLength + 10
+                );
+
+                throw new SyntaxError(e.message, original, errRange);
+            }
+
+            throw e;
+        }
+
+        const annotationLoc: OffsetRange = offsetBy(
+            offsetBy(rangeToOffsetRange(annotationLocRelToRegex), match.index),
+            meta.loc
+        );
+
+        const exprLoc = offsetBy(offsetBy(rangeToOffsetRange(exprRange), match.index), meta.loc);
+
+        if (!hasSemi) {
+            let scope: string;
+
+            if (meta.target instanceof ContractDefinition) {
+                scope = `contract ${meta.target.name}`;
+            } else {
+                const prefix =
+                    meta.target.vScope instanceof SourceUnit
+                        ? ""
+                        : (meta.target.vScope as ContractDefinition).name + ".";
+
+                scope =
+                    meta.target instanceof FunctionDefinition
+                        ? `function ${prefix}${meta.target.name}`
+                        : prefix + meta.target.name;
+            }
+
+            const errRange = rangeToLocRange(annotationLoc[0], annotationLoc[1], source);
+
+            throw new SyntaxError(
+                `Line ${errRange.start.line} of ${scope} documentation string looks like an annotation but is not terminated by a semicolon ";" and is ignored: ${annotationOrig}`,
+                annotationOrig,
+                errRange
+            );
+        }
+
+        try {
+            const exprNode = parseExpr(exprOrig);
+
+            return new Annotation(
+                meta.node,
+                meta.target,
+                annotationOrig,
+                exprOrig,
+                exprNode,
+                annotationType,
+                annotationLabel,
+                exprLoc,
+                annotationLoc,
+                meta.loc
+            );
+        } catch (e) {
+            if (e instanceof ExprPEGSSyntaxError) {
+                // Compute the syntax error offset relative to the start of the file
+                const [errStartOff, errLength] = offsetBy(
+                    [e.location.start.offset, e.location.end.offset],
+                    exprLoc
+                );
+
+                const errRange = rangeToLocRange(errStartOff, errLength, source);
+                const original = exprOrig.slice(errStartOff - 10, errStartOff + errLength + 20);
+
+                throw new SyntaxError(e.message, original, errRange);
+            }
+
+            throw e;
+        }
+    }
+
+    private validateAnnotation(target: AnnotationTarget, annotation: Annotation, source: string) {
+        if (target instanceof ContractDefinition) {
+            if (annotation.type !== AnnotationType.Invariant) {
+                throw new UnsupportedByTargetError(
+                    `Annotation type "${annotation.type}" is not applicable to a target`,
+                    annotation.original,
+                    annotation.annotationFileLoc(source)
+                );
+            }
+
+            if (target.kind === ContractKind.Interface || target.kind === ContractKind.Library) {
+                throw new UnsupportedByTargetError(
+                    `Unsupported contract annotations on ${target.kind} ${target.name}`,
+                    annotation.original,
+                    annotation.annotationFileLoc(source)
+                );
+            }
+        } else if (target instanceof FunctionDefinition) {
+            if (annotation.type !== AnnotationType.IfSucceeds) {
+                throw new UnsupportedByTargetError(
+                    `Annotation type "${annotation.type}" is not applicable to a target`,
+                    annotation.original,
+                    annotation.annotationFileLoc(source)
+                );
+            }
+
+            if (target.vScope instanceof SourceUnit) {
+                throw new UnsupportedByTargetError(
+                    `Instrumenting free functions is not supported`,
+                    annotation.original,
+                    annotation.annotationFileLoc(source)
+                );
+            }
+        }
+    }
+
     private findAnnotations(
         raw: StructuredDocumentation,
         target: AnnotationTarget,
-        source: string
+        source: string,
+        filters: AnnotationFilterOptions
     ): Annotation[] {
-        const rawText = raw.extractSourceFragment(source);
+        const rxType = filters.type === undefined ? undefined : new RegExp(filters.type);
+        const rxMsg = filters.message === undefined ? undefined : new RegExp(filters.message);
+
+        const sourceInfo = raw.sourceInfo;
+
+        const meta: RawMetaData = {
+            target: target,
+            node: raw,
+            text: raw.extractSourceFragment(source),
+            loc: [sourceInfo.offset, sourceInfo.length]
+        };
+
         const result: Annotation[] = [];
 
         const rx = /\s*(\*|\/\/\/)\s*(if_succeeds|if_aborts|invariant)/g;
 
-        let match = rx.exec(rawText);
-
-        const commentSrc = raw.sourceInfo;
-        const commentLoc: OffsetRange = [commentSrc.offset, commentSrc.length];
+        let match = rx.exec(meta.text);
 
         while (match !== null) {
-            let annotationType: AnnotationType;
-            let annotationLabel: string;
-            let annotationOrig: string;
-            let exprOrig: string;
-            let exprRange: Range;
-            let hasSemi: boolean;
-            let annotationLocRelToRegex: Range;
+            const annotation = this.makeAnnotationFromMatch(match, meta, source);
 
-            try {
-                [
-                    annotationType,
-                    annotationLabel,
-                    annotationOrig,
-                    annotationLocRelToRegex,
-                    exprOrig,
-                    exprRange,
-                    hasSemi
-                ] = parseAnnotation(rawText.slice(match.index));
-            } catch (e) {
-                if (e instanceof AnnotationPEGSSyntaxError) {
-                    // Compute the syntax error offset relative to the start of the file
-                    const [errStartOff, errLength] = offsetBy(
-                        offsetBy([e.location.start.offset, e.location.end.offset], match.index),
-                        commentLoc
-                    );
+            if (
+                (rxType === undefined || rxType.test(annotation.type)) &&
+                (rxMsg === undefined || rxMsg.test(annotation.message))
+            ) {
+                this.validateAnnotation(target, annotation, source);
 
-                    const errRange = rangeToLocRange(errStartOff, errLength, source);
-                    const original = rawText.slice(
-                        match.index,
-                        match.index + errStartOff + errLength + 10
-                    );
-
-                    throw new SyntaxError(e.message, original, errRange);
-                }
-
-                throw e;
+                result.push(annotation);
             }
 
-            const annotationLoc: OffsetRange = offsetBy(
-                offsetBy(rangeToOffsetRange(annotationLocRelToRegex), match.index),
-                commentLoc
-            );
+            rx.lastIndex = match.index + annotation.original.length;
 
-            const exprLoc = offsetBy(
-                offsetBy(rangeToOffsetRange(exprRange), match.index),
-                commentLoc
-            );
-
-            if (!hasSemi) {
-                let scope: string;
-
-                if (target instanceof ContractDefinition) {
-                    scope = `contract ${target.name}`;
-                } else {
-                    const prefix =
-                        target.vScope instanceof SourceUnit
-                            ? ""
-                            : (target.vScope as ContractDefinition).name + ".";
-
-                    scope =
-                        target instanceof FunctionDefinition
-                            ? `function ${prefix}${target.name}`
-                            : prefix + target.name;
-                }
-
-                const errRange = rangeToLocRange(annotationLoc[0], annotationLoc[1], source);
-
-                throw new SyntaxError(
-                    `Line ${errRange.start.line} of ${scope} documentation string looks like an annotation but is not terminated by a semicolon ";" and is ignored: ${annotationOrig}`,
-                    annotationOrig,
-                    errRange
-                );
-            }
-
-            try {
-                const exprNode = parseExpr(exprOrig);
-
-                result.push(
-                    new Annotation(
-                        raw,
-                        target,
-                        annotationOrig,
-                        exprOrig,
-                        exprNode,
-                        annotationType,
-                        annotationLabel,
-                        exprLoc,
-                        annotationLoc,
-                        commentLoc
-                    )
-                );
-
-                rx.lastIndex = match.index + annotationOrig.length;
-            } catch (e) {
-                if (e instanceof ExprPEGSSyntaxError) {
-                    // Compute the syntax error offset relative to the start of the file
-                    const [errStartOff, errLength] = offsetBy(
-                        [e.location.start.offset, e.location.end.offset],
-                        exprLoc
-                    );
-
-                    const errRange = rangeToLocRange(errStartOff, errLength, source);
-                    const original = exprOrig.slice(errStartOff - 10, errStartOff + errLength + 20);
-
-                    throw new SyntaxError(e.message, original, errRange);
-                }
-
-                throw e;
-            }
-
-            match = rx.exec(rawText);
+            match = rx.exec(meta.text);
         }
 
         return result;
     }
 
-    private filterAnnotationDefinitions(
-        definitions: Annotation[],
-        filterOptions: AnnotationFilterOptions
-    ): Annotation[] {
-        const rxType =
-            filterOptions.type === undefined ? undefined : new RegExp(filterOptions.type);
-
-        const rxMsg =
-            filterOptions.message === undefined ? undefined : new RegExp(filterOptions.message);
-
-        return definitions.filter((definition) => {
-            return (
-                (rxType === undefined || rxType.test(definition.type)) &&
-                (rxMsg === undefined || rxMsg.test(definition.message))
-            );
-        });
-    }
-
     extract(
         node: ContractDefinition | FunctionDefinition,
         sources: Map<string, string>,
-        filterOptions: AnnotationFilterOptions
+        filters: AnnotationFilterOptions
     ): Annotation[] {
         const result: Annotation[] = [];
 
@@ -305,7 +366,7 @@ export class AnnotationExtractor {
             let scope = overridee.vScope as ContractDefinition;
 
             while ((overridee = resolve(scope, overridee, true)) !== undefined) {
-                result.push(...this.extract(overridee, sources, filterOptions));
+                result.push(...this.extract(overridee, sources, filters));
 
                 scope = overridee.vScope as ContractDefinition;
             }
@@ -324,10 +385,9 @@ export class AnnotationExtractor {
         const unit = getScopeUnit(node);
 
         const source = sources.get(unit.absolutePath) as string;
-        const annotations = this.findAnnotations(raw, node, source);
-        const filteredAnnotations = this.filterAnnotationDefinitions(annotations, filterOptions);
+        const annotations = this.findAnnotations(raw, node, source, filters);
 
-        result.push(...filteredAnnotations);
+        result.push(...annotations);
 
         return result;
     }

--- a/test/integration/scribble/run/invalid.spec.ts
+++ b/test/integration/scribble/run/invalid.spec.ts
@@ -13,11 +13,11 @@ describe(`Command "scribble <filename>" is failing as expected`, () => {
         ],
         [
             "test/samples/if_succeeds_on_contract.invalid.sol",
-            /^test\/samples\/if_succeeds_on_contract.invalid.sol:2:4 UnsupportedByTargetError: Annotation type "if_succeeds" is not applicable to a target/m
+            /^test\/samples\/if_succeeds_on_contract.invalid.sol:2:4 UnsupportedByTargetError: The "if_succeeds" annotation is not applicable to contracts/m
         ],
         [
             "test/samples/invariant_on_function.invalid.sol",
-            /^test\/samples\/invariant_on_function.invalid.sol:2:8 UnsupportedByTargetError: Annotation type "invariant" is not applicable to a target/m
+            /^test\/samples\/invariant_on_function.invalid.sol:2:8 UnsupportedByTargetError: The "invariant" annotation is not applicable to functions/m
         ],
         [
             "test/samples/if_succeeds_on_free_function.invalid.sol",

--- a/test/integration/scribble/run/invalid.spec.ts
+++ b/test/integration/scribble/run/invalid.spec.ts
@@ -10,6 +10,10 @@ describe(`Command "scribble <filename>" is failing as expected`, () => {
         [
             "test/samples/annotation_syntax_error.invalid.sol",
             /^test\/samples\/annotation_syntax_error.invalid.sol:5:34 SyntaxError: Expected (.|\s)+ but (.|\s)+ found/m
+        ],
+        [
+            "test/samples/if_succeeds_on_contract.invalid.sol",
+            /^Annotation type "if_succeeds" is not applicable to contracts \(specified for .+\)/m
         ]
     ];
 

--- a/test/integration/scribble/run/invalid.spec.ts
+++ b/test/integration/scribble/run/invalid.spec.ts
@@ -13,7 +13,7 @@ describe(`Command "scribble <filename>" is failing as expected`, () => {
         ],
         [
             "test/samples/if_succeeds_on_contract.invalid.sol",
-            /^test\/samples\/if_succeeds_on_contract.invalid.sol:1:4 UnsupportedByTargetError: Annotation type "if_succeeds" is not applicable to a target/m
+            /^test\/samples\/if_succeeds_on_contract.invalid.sol:2:4 UnsupportedByTargetError: Annotation type "if_succeeds" is not applicable to a target/m
         ],
         [
             "test/samples/invariant_on_function.invalid.sol",

--- a/test/integration/scribble/run/invalid.spec.ts
+++ b/test/integration/scribble/run/invalid.spec.ts
@@ -13,7 +13,15 @@ describe(`Command "scribble <filename>" is failing as expected`, () => {
         ],
         [
             "test/samples/if_succeeds_on_contract.invalid.sol",
-            /^Annotation type "if_succeeds" is not applicable to contracts \(specified for .+\)/m
+            /^test\/samples\/if_succeeds_on_contract.invalid.sol:1:4 UnsupportedByTargetError: Annotation type "if_succeeds" is not applicable to a target/m
+        ],
+        [
+            "test/samples/invariant_on_function.invalid.sol",
+            /^test\/samples\/invariant_on_function.invalid.sol:2:8 UnsupportedByTargetError: Annotation type "invariant" is not applicable to a target/m
+        ],
+        [
+            "test/samples/if_succeeds_on_free_function.invalid.sol",
+            /^test\/samples\/if_succeeds_on_free_function.invalid.sol:3:4 UnsupportedByTargetError: Instrumenting free functions is not supported/m
         ]
     ];
 

--- a/test/multifile_samples/inheritance1/C.sol
+++ b/test/multifile_samples/inheritance1/C.sol
@@ -1,4 +1,4 @@
 import "./A.sol";
 import "./B.sol";
-/// if_succeeds {:msg "P1"} true;
+/// invariant {:msg "P1"} true;
 contract C is B, A { }

--- a/test/multifile_samples/inheritance1/flat.sol.expected
+++ b/test/multifile_samples/inheritance1/flat.sol.expected
@@ -34,7 +34,7 @@ contract B is __scribble_ReentrancyUtils {
         __scribble_out_of_contract = true;
     }
 }
-/// if_succeeds {:msg "P1"} true;
+/// invariant {:msg "P1"} true;
 contract C is __scribble_ReentrancyUtils, B, A {
     event AssertionFailed(string message);
 

--- a/test/multifile_samples/inheritance1/propertyMap.json.expected
+++ b/test/multifile_samples/inheritance1/propertyMap.json.expected
@@ -4,7 +4,7 @@
       "id": 0,
       "contract": "C",
       "filename": "test/multifile_samples/inheritance1/C.sol",
-      "propertySource": "64:4:2",
+      "propertySource": "62:4:2",
       "target": "contract",
       "targetName": "C",
       "message": "P1",

--- a/test/samples/if_succeeds_on_contract.invalid.sol
+++ b/test/samples/if_succeeds_on_contract.invalid.sol
@@ -1,2 +1,3 @@
+
 /// if_succeeds {:msg "Error"} true;
 contract Some {}

--- a/test/samples/if_succeeds_on_contract.invalid.sol
+++ b/test/samples/if_succeeds_on_contract.invalid.sol
@@ -1,0 +1,2 @@
+/// if_succeeds {:msg "Error"} true;
+contract Some {}

--- a/test/samples/if_succeeds_on_free_function.invalid.sol
+++ b/test/samples/if_succeeds_on_free_function.invalid.sol
@@ -1,0 +1,4 @@
+pragma solidity ^0.7.5;
+
+/// if_succeeds {:msg "Error"} true;
+function some() {}

--- a/test/samples/invariant_on_function.invalid.sol
+++ b/test/samples/invariant_on_function.invalid.sol
@@ -1,0 +1,4 @@
+contract Some {
+    /// invariant {:msg "Error"} true;
+    function other() public {}
+}


### PR DESCRIPTION
## Changes
- [x] Disallowed any annotation types, except `invariant` type on contracts.
- [x] Disallowed any annotation types, except `if_succeeds` type on functions.
- [x] Overhauled `AnnotationExtractor`:
    - Isolated annotation parsing to `makeAnnotationFromMatch()` funtion for a better readability.
    - Introduced `validateAnnotation()` method to check that created annotation is valid for the target. Moved rules from scribble executable module to this method to concentrate logic in a single place.
    - Tweaked `findAnnotations()` to respect filtering in-place and do not trigger validation on filtered out annotations.
- [x] Introduced `AnnotationError` class. The `SyntaxError` is now based on `AnnotationError`. Also introduced `UnsupportedByTargetError` class for validation errors.
- [x] Minor cleanup in scribble executable module to adapt to a new logic.
- [x] Fixed affected test samples.
- [x] Introduced test cases to check that errors are actually thrown.

Regards.