### PR TITLE
Boost tests by using NodeJS v12 for pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,7 +7,7 @@ platform:
 
 steps:
     - name: build_test
-      image: node:10
+      image: node:12
       environment:
           CODECOV_TOKEN:
               from_secret: CODECOV_TOKEN


### PR DESCRIPTION
## Changes
- [X] Tweaked Drone CI config to use NodeJS v12 image to boost tests.

Regards.