### PR TITLE
Fixes to support re-exported imports and additional tests

### DIFF
--- a/src/rewriter/import_directive.pegjs
+++ b/src/rewriter/import_directive.pegjs
@@ -108,7 +108,7 @@ Identifier =
     id:([a-zA-Z_][a-zA-Z0-9_]*) {return text(); }
 
 Symbol = 
-    name: (Identifier) alias: (__ AS __ Identifier)? { return { name, alias } as SymbolDesc }
+    name: (Identifier) alias: (__ AS __ Identifier)? { return { name, alias: alias[3] } as SymbolDesc }
 
 SymbolList =
     head: Symbol

--- a/src/rewriter/merge.ts
+++ b/src/rewriter/merge.ts
@@ -209,9 +209,14 @@ export function merge(groups: SourceUnit[][]): [SourceUnit[], ASTContext] {
                         // has submited an old compiler AST without source code.
                         continue;
                     } else {
-                        // import directives identifier's referencedDeclaration is null from the compiler.
-                        // Nothing to do here.
-                        assert(foreign.referencedDeclaration === null, ``);
+                        // import directives identifier's referencedDeclaration
+                        // is null or undefined (depending on version) from the
+                        // compiler. Nothing to do here.
+                        assert(
+                            foreign.referencedDeclaration === undefined ||
+                                foreign.referencedDeclaration === null,
+                            ``
+                        );
                     }
                 }
             } else if (child instanceof InheritanceSpecifier) {

--- a/src/rewriter/sanity.ts
+++ b/src/rewriter/sanity.ts
@@ -129,19 +129,6 @@ export function isSane(unit: SourceUnit, ctx: ASTContext): boolean {
                 if (!inCtx(def, ctx)) {
                     return false;
                 }
-
-                const id = child.symbolAliases[i].foreign;
-
-                if (def instanceof ImportDirective) {
-                    /**
-                     * @todo Handle reexported import directives properly
-                     */
-                    continue;
-                }
-
-                if (id instanceof Identifier && id.name !== def.name) {
-                    return false;
-                }
             }
 
             // 'scope' and 'vScope'

--- a/test/integration/multifile.spec.ts
+++ b/test/integration/multifile.spec.ts
@@ -5,16 +5,27 @@ import { scribble } from "./utils";
 import { join } from "path";
 
 describe("Multiple-file project instrumentation", () => {
-    const samples: Array<[string, string[]]> = [
-        ["test/multifile_samples/proj1", ["child1.sol", "child2.sol"]],
+    const samples: Array<[string, string[], string]> = [
+        ["test/multifile_samples/proj1", ["child1.sol", "child2.sol"], "0.6.11"],
         [
             "test/multifile_samples/import_rewrites",
-            ["main.sol", "imp1.sol", "imp2.sol", "imp3.sol"]
+            ["main.sol", "imp1.sol", "imp2.sol", "imp3.sol"],
+            "0.6.11"
         ],
-        ["test/multifile_samples/inheritance1", ["C.sol", "D.sol"]]
+        ["test/multifile_samples/inheritance1", ["C.sol", "D.sol"], "0.6.11"],
+        [
+            "test/multifile_samples/reexported_imports",
+            ["main.sol", "imp1.sol", "imp2.sol", "imp3.sol"],
+            "0.7.5"
+        ],
+        [
+            "test/multifile_samples/reexported_imports_05",
+            ["main.sol", "imp1.sol", "imp2.sol", "imp3.sol"],
+            "0.5.0"
+        ]
     ];
 
-    for (const [dirName, solFiles] of samples) {
+    for (const [dirName, solFiles, version] of samples) {
         describe(`Multi-file Sample ${dirName}`, () => {
             const solPaths: string[] = solFiles.map((name) => join(dirName, name));
             let expectedInstrumented: Map<string, string>;
@@ -39,7 +50,7 @@ describe("Multiple-file project instrumentation", () => {
             });
 
             it("Flat mode is correct", () => {
-                const actualFlat = scribble(solPaths, "-o", "--", "--compiler-version", "0.6.11");
+                const actualFlat = scribble(solPaths, "-o", "--", "--compiler-version", version);
                 expect(actualFlat).toEqual(expectedFlat);
             });
 
@@ -50,7 +61,7 @@ describe("Multiple-file project instrumentation", () => {
                     "files",
                     "--quiet",
                     "--compiler-version",
-                    "0.6.11"
+                    version
                 );
                 for (const [fileName, expectedContents] of expectedInstrumented) {
                     const atualInstr = fse.readFileSync(
@@ -69,7 +80,7 @@ describe("Multiple-file project instrumentation", () => {
                     "--output-mode",
                     "json",
                     "--compiler-version",
-                    "0.6.11"
+                    version
                 );
                 const actualJson = JSON.parse(actualJsonStr);
                 expect(actualJson.propertyMap).toEqual(expectedPropertyMap.propertyMap);
@@ -83,7 +94,7 @@ describe("Multiple-file project instrumentation", () => {
                     "--quiet",
                     "--arm",
                     "--compiler-version",
-                    "0.6.11"
+                    version
                 );
                 for (const [fileName, expectedContents] of expectedInstrumented) {
                     const atualInstr = fse.readFileSync(
@@ -109,7 +120,7 @@ describe("Multiple-file project instrumentation", () => {
                     "--quiet",
                     "--disarm",
                     "--compiler-version",
-                    "0.6.11"
+                    version
                 );
                 for (const [fileName, expectedContents] of expectedInstrumented) {
                     const instrFileName = fileName.replace(

--- a/test/multifile_samples/reexported_imports/flat.sol.expected
+++ b/test/multifile_samples/reexported_imports/flat.sol.expected
@@ -1,0 +1,16 @@
+pragma solidity 0.7.5;
+
+struct Foo {
+    uint x;
+}
+/// Utility contract holding a stack counter
+contract __scribble_ReentrancyUtils {
+    bool __scribble_out_of_contract = true;
+}
+
+
+contract Goo {
+    Foo internal s3;
+    Foo internal s4;
+    Foo internal s5;
+}

--- a/test/multifile_samples/reexported_imports/imp1.sol
+++ b/test/multifile_samples/reexported_imports/imp1.sol
@@ -1,0 +1,5 @@
+pragma solidity "0.7.5";
+
+struct Foo {
+	uint x;
+}

--- a/test/multifile_samples/reexported_imports/imp2.sol
+++ b/test/multifile_samples/reexported_imports/imp2.sol
@@ -1,0 +1,4 @@
+pragma solidity "0.7.5";
+
+import {Foo as Bar} from "./imp1.sol";
+import "./imp1.sol" as I1;

--- a/test/multifile_samples/reexported_imports/imp3.sol
+++ b/test/multifile_samples/reexported_imports/imp3.sol
@@ -1,0 +1,5 @@
+pragma solidity "0.7.5";
+
+import {Bar as Boo, I1 as I1} from "./imp2.sol";
+
+import "./imp2.sol" as I2;

--- a/test/multifile_samples/reexported_imports/main.sol
+++ b/test/multifile_samples/reexported_imports/main.sol
@@ -1,0 +1,10 @@
+pragma solidity "0.7.5";
+import "./imp3.sol";
+
+contract Goo {
+	//Foo s1; Foo is not in scope
+	//Bar s2; Bar is not in scope
+	Boo s3;
+	I2.Bar s4;
+	I1.Foo s5;
+}

--- a/test/multifile_samples/reexported_imports/propertyMap.json.expected
+++ b/test/multifile_samples/reexported_imports/propertyMap.json.expected
@@ -1,0 +1,3 @@
+{
+  "propertyMap": []
+}

--- a/test/multifile_samples/reexported_imports_05/flat.sol.expected
+++ b/test/multifile_samples/reexported_imports_05/flat.sol.expected
@@ -1,0 +1,36 @@
+pragma solidity 0.5.0;
+
+contract Foo {
+    uint internal x;
+
+    function foo() public pure returns (uint) {
+        return 1;
+    }
+}
+/// Utility contract holding a stack counter
+contract __scribble_ReentrancyUtils {
+    bool __scribble_out_of_contract = true;
+}
+
+contract Moo {
+    uint internal y;
+}
+contract Goo is Foo {
+    Foo internal s3;
+    Foo internal s4;
+    Foo internal s5;
+
+    function baz() public pure returns (uint) {
+        return Foo.foo();
+    }
+
+    function main() public {
+        Foo x = new Foo();
+        Foo y = new Foo();
+        Foo z = new Foo();
+        Moo w = new Moo();
+        function() internal pure returns (uint) f = Foo.foo;
+        uint t = Foo.x;
+        uint t1 = Foo.x;
+    }
+}

--- a/test/multifile_samples/reexported_imports_05/imp1.sol
+++ b/test/multifile_samples/reexported_imports_05/imp1.sol
@@ -1,0 +1,9 @@
+pragma solidity "0.5.0";
+
+contract Foo {
+	uint x;
+
+	function foo() public pure returns (uint) {
+		return 1;
+	}
+}

--- a/test/multifile_samples/reexported_imports_05/imp2.sol
+++ b/test/multifile_samples/reexported_imports_05/imp2.sol
@@ -1,0 +1,4 @@
+pragma solidity "0.5.0";
+
+import {Foo as Bar} from "./imp1.sol";
+import "./imp1.sol" as I1;

--- a/test/multifile_samples/reexported_imports_05/imp3.sol
+++ b/test/multifile_samples/reexported_imports_05/imp3.sol
@@ -1,0 +1,9 @@
+pragma solidity "0.5.0";
+
+import {Bar as Boo, I1 as I11} from "./imp2.sol";
+
+import "./imp2.sol" as I2;
+
+contract Moo {
+	uint y;
+}

--- a/test/multifile_samples/reexported_imports_05/main.sol
+++ b/test/multifile_samples/reexported_imports_05/main.sol
@@ -1,0 +1,27 @@
+pragma solidity "0.5.0";
+import "./imp3.sol";
+import "./imp3.sol" as I3;
+
+contract Goo is I11.Foo {
+	//Foo s1; Foo is not in scope
+	//Bar s2; Bar is not in scope
+	Boo s3;
+	I2.Bar s4;
+	I11.Foo s5;
+
+	function baz() public pure returns (uint) {
+		return I11.Foo.foo();
+	}
+
+	function main() public {
+		Boo x = new Boo();
+		I2.Bar y = new I2.Bar();
+		I11.Foo z = new I11.Foo();
+
+		I3.Moo w = new I3.Moo();
+
+		function() pure returns (uint) f = I11.Foo.foo;
+		uint t = I11.Foo.x;
+		uint t1 = Boo.x;
+	}
+}

--- a/test/multifile_samples/reexported_imports_05/propertyMap.json.expected
+++ b/test/multifile_samples/reexported_imports_05/propertyMap.json.expected
@@ -1,0 +1,3 @@
+{
+  "propertyMap": []
+}

--- a/test/unit/interposing.spec.ts
+++ b/test/unit/interposing.spec.ts
@@ -1,4 +1,5 @@
 import {
+    ASTContext,
     ASTNodeFactory,
     ContractDefinition,
     FunctionCall,
@@ -53,8 +54,10 @@ function makeInstrumentationCtx(
 
 function print(units: SourceUnit[], contents: string[], version: string): Map<SourceUnit, string> {
     const contentMap = new Map(units.map((unit, idx) => [unit.absolutePath, contents[idx]]));
+    const context = new ASTContext(...units);
+    const factory = new ASTNodeFactory(context);
 
-    units.forEach((unit) => rewriteImports(unit, contentMap));
+    units.forEach((unit) => rewriteImports(unit, contentMap, factory));
     const verMap: Map<SourceUnit, string> = new Map(units.map((unit) => [unit, version]));
 
     return printUnits(units, verMap);


### PR DESCRIPTION
This pr adds support for re-exported imports and unit alias imports. E.g given the following 3 files:
```
A.sol
contract Foo {..}

B.sol
import "A.sol" as A;
import {Foo as Boo} from "A.sol";

C.sol
import {A as A1} from "B.sol";
import {Boo as Moo} from "B.sol";
import "B.sol";

contract Test{
     A1.Foo x;
     Moo y;
     Boo z;
}
```

When re-writing in flat mode, all the different aliases for `Foo` - `A1.Foo`, `Boo`, `Moo` should just be rewritten to `Foo`:

```
pragma solidity 0.7.5;

contract Foo {...}
...
contract Test {
    Foo internal x;
    Foo internal y;
    Foo internal z;
}
```

Notes:
    - this PR also fixes a bug in the grammar for imports
    - it introduces the `replaceNode` function in `scribble.ts`. That function should eventually be moved to solc-typed-ast.