### PR TITLE
Don't emit empty invariant checkers on contracts with user functions

### DIFF
--- a/test/samples/userFunctions.instrumented.sol
+++ b/test/samples/userFunctions.instrumented.sol
@@ -1,16 +1,12 @@
 pragma solidity 0.7.5;
 
-/// Utility contract holding a stack counter
-contract __scribble_ReentrancyUtils {
-    bool __scribble_out_of_contract = true;
-}
 /// define plus(uint x) uint = z + x;
 ///  define plus2(uint Foo) uint = z + Foo;
 ///  define plus3(uint plus2) uint = z + plus2;
 ///  define double(uint z) uint = z+z;
 ///  define quad(uint z) uint = let res := z+z in res + res;
 ///  define quad2(uint z) uint = double(double(z));
-contract Foo is __scribble_ReentrancyUtils {
+contract Foo {
     struct vars4 {
         uint256 res;
         uint256 let_0;
@@ -50,18 +46,8 @@ contract Foo is __scribble_ReentrancyUtils {
     function quad2(uint256 z3) internal view returns (uint256) {
         return double(double(z3));
     }
-
-    /// Check only the current contract's state invariants
-    function __scribble_Foo_check_state_invariants_internal() internal {}
-
-    /// Check the state invariant for the current contract and all its bases
-    function __scribble_check_state_invariants() virtual internal {
-        __scribble_Foo_check_state_invariants_internal();
-    }
-
-    constructor() {
-        __scribble_out_of_contract = false;
-        __scribble_check_state_invariants();
-        __scribble_out_of_contract = true;
-    }
+}
+/// Utility contract holding a stack counter
+contract __scribble_ReentrancyUtils {
+    bool __scribble_out_of_contract = true;
 }

--- a/test/unit/interposing.spec.ts
+++ b/test/unit/interposing.spec.ts
@@ -447,7 +447,7 @@ contract Foo is __scribble_ReentrancyUtils {
                 assertionMode,
                 compilerVersion
             );
-            contractInstrumenter.instrument(ctx, new TypeEnv(), new Map(), [], contract);
+            contractInstrumenter.instrument(ctx, new TypeEnv(), new Map(), [], contract, true);
 
             const instrumented = print(sources, [content], "0.6.0").get(sources[0]);
 


### PR DESCRIPTION
If we have a contract with user functions but no invariants:

```
/// define one() uint = 1
contract Foo {
}
```

Scribble will currently emit a bunch of extra unnecessary state invariant checker code, due to out-of-date detection code in `scribble.ts`:

```
pragma solidity 0.8.0;

/// Utility contract holding a stack counter
contract __scribble_ReentrancyUtils {
    bool __scribble_out_of_contract = true;
}
/// define one() uint = 1
contract Foo is __scribble_ReentrancyUtils {
    event AssertionFailed(string message);

    /// Implementation of user function define one() uint256 = 1
    function one() internal view returns (uint256) {
        return 1;
    }

    /// Check only the current contract's state invariants
    function __scribble_Foo_check_state_invariants_internal() internal {
    }

    /// Check the state invariant for the current contract and all its bases
    function __scribble_check_state_invariants() virtual internal {
        __scribble_Foo_check_state_invariants_internal();
    }

    constructor() {
        __scribble_out_of_contract = false;
        __scribble_check_state_invariants();
        __scribble_out_of_contract = true;
    }
}
```

We should fix this to emit optimal instrumented code.