### PR TITLE
Wrap scribble computations in unchecked for Solidity >= 0.8.0

### DIFF
--- a/src/instrumenter/instrument.ts
+++ b/src/instrumenter/instrument.ts
@@ -859,8 +859,6 @@ export function insertInvChecks(
 ): Recipe {
     const instrCtx = transCtx.instrCtx;
     const factory = instrCtx.factory;
-    const event = getAssertionFailedEvent(factory, contract);
-
     const recipe: Recipe = [];
 
     const oldAssignmentStmts: Statement[] = instrResult.oldAssignments.map((oldAssignment) =>
@@ -872,6 +870,7 @@ export function insertInvChecks(
     );
 
     const checkStmts: Statement[] = instrResult.transpiledPredicates.map((predicate, i) => {
+        const event = getAssertionFailedEvent(factory, contract);
         const dbgInfo = instrResult.debugEventsInfo[i];
         const emitStmt = dbgInfo !== undefined ? dbgInfo[1] : undefined;
         return emitAssert(transCtx, predicate, annotations[i], event, emitStmt);

--- a/test/integration/src2srcmap.spec.ts
+++ b/test/integration/src2srcmap.spec.ts
@@ -426,15 +426,6 @@ describe("Src2src map test", () => {
                                 continue;
                             }
 
-                            // OR it must be part of the general instrumentation
-                            if (
-                                forAny(instrMD.otherInstrumentation, (range) =>
-                                    contains(range, strEntry)
-                                )
-                            ) {
-                                continue;
-                            }
-
                             // Check if this source map entry corresponds to
                             // some property check condition, and mark it
                             instrMD.propertyMap.forEach((prop, propIdx) => {
@@ -453,6 +444,15 @@ describe("Src2src map test", () => {
                                     forAny(prop.instrumentationRanges, (range) =>
                                         contains(range, strEntry)
                                     )
+                                )
+                            ) {
+                                continue;
+                            }
+
+                            // OR it must be part of the general instrumentation
+                            if (
+                                forAny(instrMD.otherInstrumentation, (range) =>
+                                    contains(range, strEntry)
                                 )
                             ) {
                                 continue;

--- a/test/samples/if_assigned_complex.instrumented.sol
+++ b/test/samples/if_assigned_complex.instrumented.sol
@@ -60,83 +60,101 @@ contract Base {
 
     function Base_x_inline_initializer() internal {
         vars1 memory _v;
-        _v.old_0 = x;
-        if (!(x >= _v.old_0)) {
-            emit AssertionFailed("0: ");
-            assert(false);
+        unchecked {
+            _v.old_0 = x;
+        }
+        unchecked {
+            if (!(x >= _v.old_0)) {
+                emit AssertionFailed("0: ");
+                assert(false);
+            }
         }
     }
 
     function Base_arr_idx_uint256_uint256_assign(uint256 ARG0, uint256 ARG1) internal returns (uint256 RET0) {
         arr[ARG0] = ARG1;
         RET0 = arr[ARG0];
-        if (!(arr.length > 0)) {
-            emit AssertionFailed("1: ");
-            assert(false);
-        }
-        if (!((0 <= ARG0) && (ARG0 <= arr.length))) {
-            emit AssertionFailed("2: ");
-            assert(false);
+        unchecked {
+            if (!(arr.length > 0)) {
+                emit AssertionFailed("1: ");
+                assert(false);
+            }
+            if (!((0 <= ARG0) && (ARG0 <= arr.length))) {
+                emit AssertionFailed("2: ");
+                assert(false);
+            }
         }
     }
 
     function Base_arr2_idx_uint256_idx_uint256_uint256_assign(uint256 ARG2, uint256 ARG3, uint256 ARG4) internal returns (uint256 RET1) {
         arr2[ARG2][ARG3] = ARG4;
         RET1 = arr2[ARG2][ARG3];
-        if (!(arr2.length > 0)) {
-            emit AssertionFailed("3: ");
-            assert(false);
-        }
-        if (!((0 <= ARG3) && (ARG3 <= arr2[ARG2].length))) {
-            emit AssertionFailed("5: ");
-            assert(false);
+        unchecked {
+            if (!(arr2.length > 0)) {
+                emit AssertionFailed("3: ");
+                assert(false);
+            }
+            if (!((0 <= ARG3) && (ARG3 <= arr2[ARG2].length))) {
+                emit AssertionFailed("5: ");
+                assert(false);
+            }
         }
     }
 
     function Base_arr2_idx_uint256_ptr_arr_uint256_storage_assign(uint256 ARG5, uint256[] storage ARG6) internal returns (uint256[] storage RET2) {
         arr2[ARG5] = ARG6;
         RET2 = arr2[ARG5];
-        if (!(arr2.length > 0)) {
-            emit AssertionFailed("3: ");
-            assert(false);
-        }
-        if (!((0 <= ARG5) && (ARG5 <= arr2.length))) {
-            emit AssertionFailed("4: ");
-            assert(false);
+        unchecked {
+            if (!(arr2.length > 0)) {
+                emit AssertionFailed("3: ");
+                assert(false);
+            }
+            if (!((0 <= ARG5) && (ARG5 <= arr2.length))) {
+                emit AssertionFailed("4: ");
+                assert(false);
+            }
         }
     }
 
     function Base_s_arr_idx_uint256_uint256_assign(uint256 ARG7, uint256 ARG8) internal returns (uint256 RET3) {
         s.arr[ARG7] = ARG8;
         RET3 = s.arr[ARG7];
-        if (!((0 <= ARG7) && (ARG7 <= s.arr.length))) {
-            emit AssertionFailed("6: ");
-            assert(false);
+        unchecked {
+            if (!((0 <= ARG7) && (ARG7 <= s.arr.length))) {
+                emit AssertionFailed("6: ");
+                assert(false);
+            }
         }
     }
 
     function Base_s_arr2_idx_uint256_idx_uint256_uint256_assign(uint256 ARG9, uint256 ARG10, uint256 ARG11) internal returns (uint256 RET4) {
         s.arr2[ARG9][ARG10] = ARG11;
         RET4 = s.arr2[ARG9][ARG10];
-        if (!((0 <= ARG10) && (ARG10 <= s.arr2[ARG9].length))) {
-            emit AssertionFailed("7: ");
-            assert(false);
+        unchecked {
+            if (!((0 <= ARG10) && (ARG10 <= s.arr2[ARG9].length))) {
+                emit AssertionFailed("7: ");
+                assert(false);
+            }
         }
     }
 
     function Base_arr_uint256_push(uint256 ARG12) internal {
         arr.push(ARG12);
-        if (!(arr.length > 0)) {
-            emit AssertionFailed("1: ");
-            assert(false);
+        unchecked {
+            if (!(arr.length > 0)) {
+                emit AssertionFailed("1: ");
+                assert(false);
+            }
         }
     }
 
     function Base_arr2_ptr_arr_uint256_storage_push(uint256[] storage ARG13) internal {
         arr2.push(ARG13);
-        if (!(arr2.length > 0)) {
-            emit AssertionFailed("3: ");
-            assert(false);
+        unchecked {
+            if (!(arr2.length > 0)) {
+                emit AssertionFailed("3: ");
+                assert(false);
+            }
         }
     }
 }

--- a/test/samples/if_assigned_inline_initializers.instrumented.sol
+++ b/test/samples/if_assigned_inline_initializers.instrumented.sol
@@ -23,10 +23,14 @@ contract Base {
 
     function Base_x_inline_initializer() internal {
         vars0 memory _v;
-        _v.old_0 = x;
-        if (!(x >= _v.old_0)) {
-            emit AssertionFailed("0: ");
-            assert(false);
+        unchecked {
+            _v.old_0 = x;
+        }
+        unchecked {
+            if (!(x >= _v.old_0)) {
+                emit AssertionFailed("0: ");
+                assert(false);
+            }
         }
     }
 
@@ -38,52 +42,66 @@ contract Base {
     }
 
     function Base_arr_inline_initializer() internal {
-        if (!(arr.length > 0)) {
-            emit AssertionFailed("1: ");
-            assert(false);
+        unchecked {
+            if (!(arr.length > 0)) {
+                emit AssertionFailed("1: ");
+                assert(false);
+            }
         }
     }
 
     function Base_arr2_inline_initializer() internal {
-        if (!(arr2.length > 0)) {
-            emit AssertionFailed("3: ");
-            assert(false);
+        unchecked {
+            if (!(arr2.length > 0)) {
+                emit AssertionFailed("3: ");
+                assert(false);
+            }
         }
     }
 
     function Base_s_inline_initializer() internal {
-        if (!(s.arr.length > 0)) {
-            emit AssertionFailed("6: ");
-            assert(false);
+        unchecked {
+            if (!(s.arr.length > 0)) {
+                emit AssertionFailed("6: ");
+                assert(false);
+            }
         }
     }
 
     function Base_x_uint256_assign(uint256 ARG0) internal returns (uint256 RET0) {
         vars4 memory _v;
-        _v.old_1 = x;
+        unchecked {
+            _v.old_1 = x;
+        }
         x = ARG0;
         RET0 = x;
-        if (!(x >= _v.old_1)) {
-            emit AssertionFailed("0: ");
-            assert(false);
+        unchecked {
+            if (!(x >= _v.old_1)) {
+                emit AssertionFailed("0: ");
+                assert(false);
+            }
         }
     }
 
     function Base_arr_ptr_arr_uint8_1_memory_assign(uint8[1] memory ARG1) internal returns (uint256[] storage RET1) {
         arr = ARG1;
         RET1 = arr;
-        if (!(arr.length > 0)) {
-            emit AssertionFailed("1: ");
-            assert(false);
+        unchecked {
+            if (!(arr.length > 0)) {
+                emit AssertionFailed("1: ");
+                assert(false);
+            }
         }
     }
 
     function Base_arr2_ptr_arr_ptr_arr_uint8_1_memory_2_memory_assign(uint8[1][2] memory ARG2) internal returns (uint256[][] storage RET2) {
         arr2 = ARG2;
         RET2 = arr2;
-        if (!(arr2.length > 0)) {
-            emit AssertionFailed("3: ");
-            assert(false);
+        unchecked {
+            if (!(arr2.length > 0)) {
+                emit AssertionFailed("3: ");
+                assert(false);
+            }
         }
     }
 }

--- a/test/samples/if_assigned_primitive.instrumented.sol
+++ b/test/samples/if_assigned_primitive.instrumented.sol
@@ -55,91 +55,117 @@ contract Base {
     }
 
     function Base_x_inline_initializer() internal {
-        if (!(x >= 1)) {
-            emit AssertionFailed("0: ");
-            assert(false);
+        unchecked {
+            if (!(x >= 1)) {
+                emit AssertionFailed("0: ");
+                assert(false);
+            }
         }
     }
 
     function Base_y_inline_initializer() internal {
         vars1 memory _v;
-        _v.old_0 = y;
-        if (!(y >= _v.old_0)) {
-            emit AssertionFailed("1: ");
-            assert(false);
+        unchecked {
+            _v.old_0 = y;
+        }
+        unchecked {
+            if (!(y >= _v.old_0)) {
+                emit AssertionFailed("1: ");
+                assert(false);
+            }
         }
     }
 
     function Base_a_inline_initializer() internal {
-        if (!(uint160(a) >= 1)) {
-            emit AssertionFailed("2: ");
-            assert(false);
+        unchecked {
+            if (!(uint160(a) >= 1)) {
+                emit AssertionFailed("2: ");
+                assert(false);
+            }
         }
     }
 
     function Base_x_uint256_assign(uint256 ARG0) internal returns (uint256 RET0) {
         x = ARG0;
         RET0 = x;
-        if (!(x >= 1)) {
-            emit AssertionFailed("0: ");
-            assert(false);
+        unchecked {
+            if (!(x >= 1)) {
+                emit AssertionFailed("0: ");
+                assert(false);
+            }
         }
     }
 
     function Base_a_address_assign(address ARG1) internal returns (address RET1) {
         a = ARG1;
         RET1 = a;
-        if (!(uint160(a) >= 1)) {
-            emit AssertionFailed("2: ");
-            assert(false);
+        unchecked {
+            if (!(uint160(a) >= 1)) {
+                emit AssertionFailed("2: ");
+                assert(false);
+            }
         }
     }
 
     function Base_y_uint256_assign(uint256 ARG2) internal returns (uint256 RET2) {
         vars5 memory _v;
-        _v.old_1 = y;
+        unchecked {
+            _v.old_1 = y;
+        }
         y = ARG2;
         RET2 = y;
-        if (!(y >= _v.old_1)) {
-            emit AssertionFailed("1: ");
-            assert(false);
+        unchecked {
+            if (!(y >= _v.old_1)) {
+                emit AssertionFailed("1: ");
+                assert(false);
+            }
         }
     }
 
     function Base_x_inc_postfix() internal returns (uint256 RET3) {
         RET3 = x;
         x++;
-        if (!(x >= 1)) {
-            emit AssertionFailed("0: ");
-            assert(false);
+        unchecked {
+            if (!(x >= 1)) {
+                emit AssertionFailed("0: ");
+                assert(false);
+            }
         }
     }
 
     function Base_y_inc_postfix() internal returns (uint256 RET4) {
         vars7 memory _v;
-        _v.old_2 = y;
+        unchecked {
+            _v.old_2 = y;
+        }
         RET4 = y;
         y++;
-        if (!(y >= _v.old_2)) {
-            emit AssertionFailed("1: ");
-            assert(false);
+        unchecked {
+            if (!(y >= _v.old_2)) {
+                emit AssertionFailed("1: ");
+                assert(false);
+            }
         }
     }
 
     function Base_x_delete() internal {
         delete x;
-        if (!(x >= 1)) {
-            emit AssertionFailed("0: ");
-            assert(false);
+        unchecked {
+            if (!(x >= 1)) {
+                emit AssertionFailed("0: ");
+                assert(false);
+            }
         }
     }
 
     function Base_x_inc_prefix() internal returns (uint256 RET5) {
         ++x;
         RET5 = x;
-        if (!(x >= 1)) {
-            emit AssertionFailed("0: ");
-            assert(false);
+        unchecked {
+            if (!(x >= 1)) {
+                emit AssertionFailed("0: ");
+                assert(false);
+            }
         }
     }
 }

--- a/test/samples/if_updated_aliasing.instrumented.sol
+++ b/test/samples/if_updated_aliasing.instrumented.sol
@@ -45,34 +45,42 @@ contract IfUpdatedAliasing {
     function IfUpdatedAliasing_a1_idx_uint256_uint256_assign(uint256 ARG0, uint256 ARG1) internal returns (uint256 RET0) {
         a1[ARG0] = ARG1;
         RET0 = a1[ARG0];
-        if (!(true)) {
-            emit AssertionFailed("0: ");
-            assert(false);
+        unchecked {
+            if (!(true)) {
+                emit AssertionFailed("0: ");
+                assert(false);
+            }
         }
     }
 
     function IfUpdatedAliasing_aa1_idx_uint256_ptr_arr_uint256_storage_assign(uint256 ARG2, uint256[] storage ARG3) internal returns (uint256[] storage RET1) {
         aa1[ARG2] = ARG3;
         RET1 = aa1[ARG2];
-        if (!(true)) {
-            emit AssertionFailed("1: ");
-            assert(false);
+        unchecked {
+            if (!(true)) {
+                emit AssertionFailed("1: ");
+                assert(false);
+            }
         }
     }
 
     function IfUpdatedAliasing_a1_uint256_push(uint256 ARG4) internal {
         a1.push(ARG4);
-        if (!(true)) {
-            emit AssertionFailed("0: ");
-            assert(false);
+        unchecked {
+            if (!(true)) {
+                emit AssertionFailed("0: ");
+                assert(false);
+            }
         }
     }
 
     function IfUpdatedAliasing_aa1_ptr_arr_uint256_storage_push(uint256[] storage ARG5) internal {
         aa1.push(ARG5);
-        if (!(true)) {
-            emit AssertionFailed("1: ");
-            assert(false);
+        unchecked {
+            if (!(true)) {
+                emit AssertionFailed("1: ");
+                assert(false);
+            }
         }
     }
 }

--- a/test/samples/if_updated_inline_initializers.instrumented.sol
+++ b/test/samples/if_updated_inline_initializers.instrumented.sol
@@ -23,10 +23,14 @@ contract Base {
 
     function Base_x_inline_initializer() internal {
         vars0 memory _v;
-        _v.old_0 = x;
-        if (!(x >= _v.old_0)) {
-            emit AssertionFailed("0: ");
-            assert(false);
+        unchecked {
+            _v.old_0 = x;
+        }
+        unchecked {
+            if (!(x >= _v.old_0)) {
+                emit AssertionFailed("0: ");
+                assert(false);
+            }
         }
     }
 
@@ -38,70 +42,88 @@ contract Base {
     }
 
     function Base_arr_inline_initializer() internal {
-        if (!(arr.length > 0)) {
-            emit AssertionFailed("1: ");
-            assert(false);
+        unchecked {
+            if (!(arr.length > 0)) {
+                emit AssertionFailed("1: ");
+                assert(false);
+            }
         }
     }
 
     function Base_arr2_inline_initializer() internal {
-        if (!(arr2.length > 0)) {
-            emit AssertionFailed("2: ");
-            assert(false);
+        unchecked {
+            if (!(arr2.length > 0)) {
+                emit AssertionFailed("2: ");
+                assert(false);
+            }
         }
     }
 
     function Base_s_inline_initializer() internal {
-        if (!(s.arr.length > 0)) {
-            emit AssertionFailed("3: ");
-            assert(false);
+        unchecked {
+            if (!(s.arr.length > 0)) {
+                emit AssertionFailed("3: ");
+                assert(false);
+            }
         }
     }
 
     function Base_x_uint256_assign(uint256 ARG0) internal returns (uint256 RET0) {
         vars4 memory _v;
-        _v.old_1 = x;
+        unchecked {
+            _v.old_1 = x;
+        }
         x = ARG0;
         RET0 = x;
-        if (!(x >= _v.old_1)) {
-            emit AssertionFailed("0: ");
-            assert(false);
+        unchecked {
+            if (!(x >= _v.old_1)) {
+                emit AssertionFailed("0: ");
+                assert(false);
+            }
         }
     }
 
     function Base_arr_ptr_arr_uint8_1_memory_assign(uint8[1] memory ARG1) internal returns (uint256[] storage RET1) {
         arr = ARG1;
         RET1 = arr;
-        if (!(arr.length > 0)) {
-            emit AssertionFailed("1: ");
-            assert(false);
+        unchecked {
+            if (!(arr.length > 0)) {
+                emit AssertionFailed("1: ");
+                assert(false);
+            }
         }
     }
 
     function Base_arr2_ptr_arr_ptr_arr_uint8_1_memory_2_memory_assign(uint8[1][2] memory ARG2) internal returns (uint256[][] storage RET2) {
         arr2 = ARG2;
         RET2 = arr2;
-        if (!(arr2.length > 0)) {
-            emit AssertionFailed("2: ");
-            assert(false);
+        unchecked {
+            if (!(arr2.length > 0)) {
+                emit AssertionFailed("2: ");
+                assert(false);
+            }
         }
     }
 
     function Base_s_arr_ptr_arr_uint256_storage_assign(uint256[] storage ARG3) internal returns (uint256[] storage RET3) {
         s.arr = ARG3;
         RET3 = s.arr;
-        if (!(s.arr.length > 0)) {
-            emit AssertionFailed("3: ");
-            assert(false);
+        unchecked {
+            if (!(s.arr.length > 0)) {
+                emit AssertionFailed("3: ");
+                assert(false);
+            }
         }
     }
 
     function Base_s_arr2_ptr_arr_ptr_arr_uint256_storage_storage_assign(uint256[][] storage ARG4) internal returns (uint256[][] storage RET4) {
         s.arr2 = ARG4;
         RET4 = s.arr2;
-        if (!(s.arr.length > 0)) {
-            emit AssertionFailed("3: ");
-            assert(false);
+        unchecked {
+            if (!(s.arr.length > 0)) {
+                emit AssertionFailed("3: ");
+                assert(false);
+            }
         }
     }
 }

--- a/test/samples/if_updated_primitive.instrumented.sol
+++ b/test/samples/if_updated_primitive.instrumented.sol
@@ -50,91 +50,117 @@ contract Base {
     }
 
     function Base_x_inline_initializer() internal {
-        if (!(x >= 1)) {
-            emit AssertionFailed("0: ");
-            assert(false);
+        unchecked {
+            if (!(x >= 1)) {
+                emit AssertionFailed("0: ");
+                assert(false);
+            }
         }
     }
 
     function Base_y_inline_initializer() internal {
         vars1 memory _v;
-        _v.old_0 = y;
-        if (!(y >= _v.old_0)) {
-            emit AssertionFailed("1: ");
-            assert(false);
+        unchecked {
+            _v.old_0 = y;
+        }
+        unchecked {
+            if (!(y >= _v.old_0)) {
+                emit AssertionFailed("1: ");
+                assert(false);
+            }
         }
     }
 
     function Base_a_inline_initializer() internal {
-        if (!(uint160(a) >= 1)) {
-            emit AssertionFailed("3: ");
-            assert(false);
+        unchecked {
+            if (!(uint160(a) >= 1)) {
+                emit AssertionFailed("3: ");
+                assert(false);
+            }
         }
     }
 
     function Base_x_uint256_assign(uint256 ARG0) internal returns (uint256 RET0) {
         x = ARG0;
         RET0 = x;
-        if (!(x >= 1)) {
-            emit AssertionFailed("0: ");
-            assert(false);
+        unchecked {
+            if (!(x >= 1)) {
+                emit AssertionFailed("0: ");
+                assert(false);
+            }
         }
     }
 
     function Base_a_address_assign(address ARG1) internal returns (address RET1) {
         a = ARG1;
         RET1 = a;
-        if (!(uint160(a) >= 1)) {
-            emit AssertionFailed("3: ");
-            assert(false);
+        unchecked {
+            if (!(uint160(a) >= 1)) {
+                emit AssertionFailed("3: ");
+                assert(false);
+            }
         }
     }
 
     function Base_y_uint256_assign(uint256 ARG2) internal returns (uint256 RET2) {
         vars5 memory _v;
-        _v.old_1 = y;
+        unchecked {
+            _v.old_1 = y;
+        }
         y = ARG2;
         RET2 = y;
-        if (!(y >= _v.old_1)) {
-            emit AssertionFailed("1: ");
-            assert(false);
+        unchecked {
+            if (!(y >= _v.old_1)) {
+                emit AssertionFailed("1: ");
+                assert(false);
+            }
         }
     }
 
     function Base_x_inc_postfix() internal returns (uint256 RET3) {
         RET3 = x;
         x++;
-        if (!(x >= 1)) {
-            emit AssertionFailed("0: ");
-            assert(false);
+        unchecked {
+            if (!(x >= 1)) {
+                emit AssertionFailed("0: ");
+                assert(false);
+            }
         }
     }
 
     function Base_y_inc_postfix() internal returns (uint256 RET4) {
         vars7 memory _v;
-        _v.old_2 = y;
+        unchecked {
+            _v.old_2 = y;
+        }
         RET4 = y;
         y++;
-        if (!(y >= _v.old_2)) {
-            emit AssertionFailed("1: ");
-            assert(false);
+        unchecked {
+            if (!(y >= _v.old_2)) {
+                emit AssertionFailed("1: ");
+                assert(false);
+            }
         }
     }
 
     function Base_t_delete() internal {
         delete t;
-        if (!(t == 0)) {
-            emit AssertionFailed("2: ");
-            assert(false);
+        unchecked {
+            if (!(t == 0)) {
+                emit AssertionFailed("2: ");
+                assert(false);
+            }
         }
     }
 
     function Base_x_inc_prefix() internal returns (uint256 RET5) {
         ++x;
         RET5 = x;
-        if (!(x >= 1)) {
-            emit AssertionFailed("0: ");
-            assert(false);
+        unchecked {
+            if (!(x >= 1)) {
+                emit AssertionFailed("0: ");
+                assert(false);
+            }
         }
     }
 }

--- a/test/samples/if_updated_tuples.instrumented.sol
+++ b/test/samples/if_updated_tuples.instrumented.sol
@@ -57,34 +57,42 @@ contract IfUpdatedPrimitive {
     }
 
     function IfUpdatedPrimitive_x_inline_initializer() internal {
-        if (!(x >= 1)) {
-            emit AssertionFailed("0: ");
-            assert(false);
+        unchecked {
+            if (!(x >= 1)) {
+                emit AssertionFailed("0: ");
+                assert(false);
+            }
         }
     }
 
     function IfUpdatedPrimitive_a_inline_initializer() internal {
-        if (!(uint160(a) >= 1)) {
-            emit AssertionFailed("1: ");
-            assert(false);
+        unchecked {
+            if (!(uint160(a) >= 1)) {
+                emit AssertionFailed("1: ");
+                assert(false);
+            }
         }
     }
 
     function IfUpdatedPrimitive_x_uint256_assign(uint256 ARG0) internal returns (uint256 RET0) {
         x = ARG0;
         RET0 = x;
-        if (!(x >= 1)) {
-            emit AssertionFailed("0: ");
-            assert(false);
+        unchecked {
+            if (!(x >= 1)) {
+                emit AssertionFailed("0: ");
+                assert(false);
+            }
         }
     }
 
     function IfUpdatedPrimitive_a_address_assign(address ARG1) internal returns (address RET1) {
         a = ARG1;
         RET1 = a;
-        if (!(uint160(a) >= 1)) {
-            emit AssertionFailed("1: ");
-            assert(false);
+        unchecked {
+            if (!(uint160(a) >= 1)) {
+                emit AssertionFailed("1: ");
+                assert(false);
+            }
         }
     }
 }

--- a/test/samples/if_updated_unsafe.instrumented.sol
+++ b/test/samples/if_updated_unsafe.instrumented.sol
@@ -1,5 +1,6 @@
 pragma solidity 0.8.3;
 
+/// define id(uint x) uint = x + 1 - 1;
 contract TestUnchecked {
     event AssertionFailed(string message);
 
@@ -9,27 +10,35 @@ contract TestUnchecked {
         _original_TestUnchecked_foo();
         unchecked {
             if (!(x == 1)) {
-                emit AssertionFailed("2: S1");
+                emit AssertionFailed("3: S1");
                 assert(false);
             }
         }
     }
 
     function _original_TestUnchecked_foo() private {
-        TestUnchecked_x_uint8_assign(255);
+        TestUnchecked_x_uint8_assign(254);
+        TestUnchecked_x_uint8_plus_assign(1);
         unchecked {
-            TestUnchecked_x_uint8_plus_assign(2);
+            TestUnchecked_x_uint8_plus_assign_unchecked(2);
+        }
+    }
+
+    /// Implementation of user function define id(uint256 x) uint256 = ((x + 1) - 1)
+    function id(uint256 x1) internal view returns (uint256) {
+        unchecked {
+            return (x1 + 1) - 1;
         }
     }
 
     function TestUnchecked_x_inline_initializer() internal {
         unchecked {
-            if (!(x > 0)) {
-                emit AssertionFailed("0: A1");
+            if (!(id(x) > 0)) {
+                emit AssertionFailed("1: A1");
                 assert(false);
             }
             if (!(x > 0)) {
-                emit AssertionFailed("1: U1");
+                emit AssertionFailed("2: U1");
                 assert(false);
             }
         }
@@ -43,29 +52,44 @@ contract TestUnchecked {
         x = ARG0;
         RET0 = x;
         unchecked {
-            if (!(x > 0)) {
-                emit AssertionFailed("0: A1");
+            if (!(id(x) > 0)) {
+                emit AssertionFailed("1: A1");
                 assert(false);
             }
             if (!(x > 0)) {
-                emit AssertionFailed("1: U1");
+                emit AssertionFailed("2: U1");
                 assert(false);
             }
         }
     }
 
     function TestUnchecked_x_uint8_plus_assign(uint8 ARG1) internal returns (uint8 RET1) {
-        unchecked {
-            x += ARG1;
-        }
+        x += ARG1;
         RET1 = x;
         unchecked {
-            if (!(x > 0)) {
-                emit AssertionFailed("0: A1");
+            if (!(id(x) > 0)) {
+                emit AssertionFailed("1: A1");
                 assert(false);
             }
             if (!(x > 0)) {
-                emit AssertionFailed("1: U1");
+                emit AssertionFailed("2: U1");
+                assert(false);
+            }
+        }
+    }
+
+    function TestUnchecked_x_uint8_plus_assign_unchecked(uint8 ARG2) internal returns (uint8 RET2) {
+        unchecked {
+            x += ARG2;
+        }
+        RET2 = x;
+        unchecked {
+            if (!(id(x) > 0)) {
+                emit AssertionFailed("1: A1");
+                assert(false);
+            }
+            if (!(x > 0)) {
+                emit AssertionFailed("2: U1");
                 assert(false);
             }
         }

--- a/test/samples/if_updated_unsafe.instrumented.sol
+++ b/test/samples/if_updated_unsafe.instrumented.sol
@@ -7,9 +7,11 @@ contract TestUnchecked {
 
     function foo() public {
         _original_TestUnchecked_foo();
-        if (!(x == 1)) {
-            emit AssertionFailed("2: S1");
-            assert(false);
+        unchecked {
+            if (!(x == 1)) {
+                emit AssertionFailed("2: S1");
+                assert(false);
+            }
         }
     }
 
@@ -21,13 +23,15 @@ contract TestUnchecked {
     }
 
     function TestUnchecked_x_inline_initializer() internal {
-        if (!(x > 0)) {
-            emit AssertionFailed("0: A1");
-            assert(false);
-        }
-        if (!(x > 0)) {
-            emit AssertionFailed("1: U1");
-            assert(false);
+        unchecked {
+            if (!(x > 0)) {
+                emit AssertionFailed("0: A1");
+                assert(false);
+            }
+            if (!(x > 0)) {
+                emit AssertionFailed("1: U1");
+                assert(false);
+            }
         }
     }
 
@@ -38,13 +42,15 @@ contract TestUnchecked {
     function TestUnchecked_x_uint8_assign(uint8 ARG0) internal returns (uint8 RET0) {
         x = ARG0;
         RET0 = x;
-        if (!(x > 0)) {
-            emit AssertionFailed("0: A1");
-            assert(false);
-        }
-        if (!(x > 0)) {
-            emit AssertionFailed("1: U1");
-            assert(false);
+        unchecked {
+            if (!(x > 0)) {
+                emit AssertionFailed("0: A1");
+                assert(false);
+            }
+            if (!(x > 0)) {
+                emit AssertionFailed("1: U1");
+                assert(false);
+            }
         }
     }
 
@@ -53,13 +59,15 @@ contract TestUnchecked {
             x += ARG1;
         }
         RET1 = x;
-        if (!(x > 0)) {
-            emit AssertionFailed("0: A1");
-            assert(false);
-        }
-        if (!(x > 0)) {
-            emit AssertionFailed("1: U1");
-            assert(false);
+        unchecked {
+            if (!(x > 0)) {
+                emit AssertionFailed("0: A1");
+                assert(false);
+            }
+            if (!(x > 0)) {
+                emit AssertionFailed("1: U1");
+                assert(false);
+            }
         }
     }
 }

--- a/test/samples/if_updated_unsafe.sol
+++ b/test/samples/if_updated_unsafe.sol
@@ -1,13 +1,16 @@
 pragma solidity 0.8.3;
 
+/// define id(uint x) uint = x + 1 - 1;
 contract TestUnchecked {
-    //// if_assigned {:msg "A1"} x > 0;
+    //// if_assigned {:msg "A1"} id(x) > 0;
     //// if_updated {:msg "U1"} x > 0;
     uint8 x = 100;
 
     /// if_succeeds {:msg "S1"} x == 1;
     function foo() public {
-        x = 255;
+        x = 254;
+
+        x += 1;
 
         unchecked {
             x += 2;


### PR DESCRIPTION
After 0.8.0 Solidity arithmetic becomes 'checked' by default. In order to:

1. Have consistent behavior with Scribble pre-0.8.0
2. Ensure that spec computation does not risk throwing additional errors
3. Make it easier to write specs about functions containing unchecked computation

We have decided that scribble specs will have **unchecked** semantics. I.e. they may silently overflow without reverting.
To implement this, we wrap all scribble instrumentation-related computation in `unchecked {}` blocks.