### PR TITLE
Fix for Issue #28

### DIFF
--- a/src/instrumenter/annotations.ts
+++ b/src/instrumenter/annotations.ts
@@ -382,7 +382,7 @@ class AnnotationExtractor {
 
         const result: AnnotationMetaData[] = [];
 
-        const rx = /\s*(\*|\/\/\/)\s*(if_succeeds|if_updated|if_assigned|invariant|define\s*[a-zA-Z0-9_]*\([^)]*\))/g;
+        const rx = /\s*(\*|\/\/\/)\s*(if_succeeds|if_updated|if_assigned|invariant|define\s*[a-zA-Z0-9_]*\s*\([^)]*\))/g;
 
         let match = rx.exec(meta.text);
 

--- a/src/instrumenter/annotations.ts
+++ b/src/instrumenter/annotations.ts
@@ -382,7 +382,7 @@ class AnnotationExtractor {
 
         const result: AnnotationMetaData[] = [];
 
-        const rx = /\s*(\*|\/\/\/)\s*(if_succeeds|if_updated|if_assigned|invariant|define)/g;
+        const rx = /\s*(\*|\/\/\/)\s*(if_succeeds|if_updated|if_assigned|invariant|define\s*[a-zA-Z0-9_]*\([^)]*\))/g;
 
         let match = rx.exec(meta.text);
 

--- a/test/samples/misc.instrumented.sol
+++ b/test/samples/misc.instrumented.sol
@@ -231,6 +231,10 @@ contract ExternalCall {
         return _bytes.length > 0;
     }
 }
+
+/// define some stuff
+///  define some(other stuff
+contract IgnoreNonFunDefines {}
 /// Utility contract holding a stack counter
 contract __scribble_ReentrancyUtils {
     bool __scribble_out_of_contract = true;

--- a/test/samples/misc.sol
+++ b/test/samples/misc.sol
@@ -110,3 +110,8 @@ contract ExternalCall {
         return _bytes.length > 0;
     }
 }
+/// define some stuff
+/// define some(other stuff
+contract IgnoreNonFunDefines {
+    
+}


### PR DESCRIPTION
This PR fixes #28. Essentially we make the first-pass regex that finds candidate annotations in docstrings match more-precisely to `define`-s that look like function definitions.