### PR TITLE
Fix bug in 0.4.1 compilation of let statements in 0.8.x

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -15,5 +15,5 @@ steps:
           - npm install --unsafe-perm
           - npm link --unsafe-perm
           - npm run lint
-          - npm test
+          - npm run test:ci
           - npm run coverage:upload

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "transpile": "tsc",
         "build": "npm run clean && npm run build-parsers && npm run transpile",
         "test": "NODE_OPTIONS='--max-old-space-size=2048' nyc mocha",
+        "test:ci": "NODE_OPTIONS='--max-old-space-size=2048' nyc mocha --parallel --jobs 4",
         "coverage:upload": "nyc report --reporter=text-lcov > coverage.lcov && codecov -t $CODECOV_TOKEN",
         "lint": "eslint src/ test/ --ext=ts",
         "lint:fix": "eslint src/ test/ --ext=ts --fix",

--- a/src/instrumenter/instrument.ts
+++ b/src/instrumenter/instrument.ts
@@ -897,7 +897,7 @@ export function insertInvChecks(
         }
 
         if (newAssignmentStmts.length > 0) {
-            const newAssignmenBlock = factory.makeUncheckedBlock(oldAssignmentStmts);
+            const newAssignmenBlock = factory.makeUncheckedBlock(newAssignmentStmts);
             recipe.push(new InsertStatement(factory, newAssignmenBlock, "end", body));
         }
 


### PR DESCRIPTION
Compiling of `let` statements in 0.8.x is broken in version 0.4.1. Specifically we were placing `old-` bindings in the unchecked block where `let-` bindings should be placed. This PR fixes this and makes CI run mocha tests in parallel to avoid timeouts.