### PR TITLE
Fix for Issue #31: Failure with "using for" over address

### DIFF
--- a/src/spec-lang/tc/typecheck.ts
+++ b/src/spec-lang/tc/typecheck.ts
@@ -1360,28 +1360,14 @@ export function tcMemberAccess(expr: SMemberAccess, ctx: STypingCtx, typeEnv: Ty
         if (type) {
             return type;
         }
-
-        throw new SNoField(
-            `Contract ${baseT.name} doesn't have a function, public state variable or address builtin member ${expr.member}`,
-            expr,
-            expr.member
-        );
     }
 
     if (baseT instanceof AddressType) {
         const type = BuiltinAddressMembers.get(expr.member);
 
-        if (type === undefined) {
-            throw new SNoField(
-                `Address type expression ${expr.base.pp()} doesn't have a builtin member ${
-                    expr.member
-                }`,
-                expr,
-                expr.member
-            );
+        if (type !== undefined) {
+            return type;
         }
-
-        return type;
     }
 
     if (

--- a/test/unit/tc.spec.ts
+++ b/test/unit/tc.spec.ts
@@ -77,6 +77,14 @@ describe("TypeChecker Expression Unit Tests", () => {
                 function foo(int128 x) public returns (bool) {
                     return true;
                 }
+
+                function balanceOf(address x) internal pure returns (uint) {
+                    return 123;
+                }
+
+                function balanceOf2(Foo x) internal pure returns (uint) {
+                    return 123;
+                }
             }
 
             library Lib3 {
@@ -336,6 +344,8 @@ describe("TypeChecker Expression Unit Tests", () => {
                     ["Foo", undefined],
                     new PointerType(new BytesType(), DataLocation.Storage)
                 ],
+                ["address(0x0).balanceOf()", ["Foo", undefined], new IntType(256, false)],
+                ["this.balanceOf2()", ["Foo", undefined], new IntType(256, false)],
                 ["add(5,5)", ["Foo", undefined], new IntType(64, false)],
                 ["old(5)", ["Foo", "add"], new IntLiteralType()],
                 ["old(sV1)", ["Foo", "add"], new IntType(128, true)],


### PR DESCRIPTION
Fixes https://github.com/ConsenSys/scribble/issues/33. The issue was that we were too aggressive in type-checking MemberAccess-es where the base was of type address or contract, terminating early and preventing code further down in `tcMemberAccess` from checkin if any `using for ...` declarations match the access. The fix is to just remove the early termination errors.