### PR TITLE
Bug when instrumenting constructors in 0.8.x

### DIFF
--- a/src/instrumenter/interpose.ts
+++ b/src/instrumenter/interpose.ts
@@ -198,6 +198,7 @@ export function interpose(
     fun.documentation = undefined;
     stub.documentation = undefined;
     fun.visibility = FunctionVisibility.Private;
+    fun.isConstructor = false;
     renameReturns(stub);
     stub.vModifiers = [];
     stub.vBody?.appendChild(callOriginal(ctx, stub, fun));


### PR DESCRIPTION
[NOTE: This PR should be merged after the forall PR #40]

In 0.8.x when we annotate a constructor, the resulting instrumented codedoesn't compile as the renamed constructor is missing its visibility. This is due to the fact that we forget to set `isConstructor` on the
renamed constructor to false, and as a result `solc-typed-ast` doesn't
print the visibility. Fix this.