### PR TITLE
Cleanup in grammars

### DIFF
--- a/src/rewriter/import_directive.pegjs
+++ b/src/rewriter/import_directive.pegjs
@@ -31,8 +31,8 @@ LineTerminatorSequence "end of line" =
     / "\u2028"
     / "\u2029"
 
-__
-    = (WhiteSpace / LineTerminator)*
+__ =
+    (WhiteSpace / LineTerminator)*
 
 IMPORT = "import"
 AS = "as"

--- a/src/rewriter/import_directive.pegjs
+++ b/src/rewriter/import_directive.pegjs
@@ -114,7 +114,7 @@ Identifier =
 
 Symbol = 
     name: (Identifier) alias: (__ AS __ Identifier)? {
-        return { name, alias: alias[3] } as SymbolDesc
+        return { name, alias: alias[3] } as SymbolDesc;
     }
 
 SymbolList =

--- a/src/rewriter/import_directive.pegjs
+++ b/src/rewriter/import_directive.pegjs
@@ -1,79 +1,80 @@
-Start =
+Entry =
     __ directive: ImportDirective __ { return directive; }
 
-PrimitiveWhiteSpace "whitespace"
-  = "\t"
-  / "\v"
-  / "\f"
-  / " "
-  / "\u00A0"
-  / "\uFEFF"
-  / Zs
+PrimitiveWhiteSpace "whitespace" =
+    "\t"
+    / "\v"
+    / "\f"
+    / " "
+    / "\u00A0"
+    / "\uFEFF"
+    / Zs
 
-WhiteSpace "whitespace"
-  = PrimitiveWhiteSpace
-  / LineTerminator PrimitiveWhiteSpace* ("*" / "///")
+WhiteSpace "whitespace" =
+    PrimitiveWhiteSpace
+    / LineTerminator PrimitiveWhiteSpace* ("*" / "///")
 
-StartingWhiteSpace "whitespace"
-  = PrimitiveWhiteSpace* LineTerminator? PrimitiveWhiteSpace* ("*" / "///")? __ 
+StartingWhiteSpace "whitespace" =
+    PrimitiveWhiteSpace* LineTerminator? PrimitiveWhiteSpace* ("*" / "///")? __ 
 
 // Separator, Space
-Zs = [\u0020\u00A0\u1680\u2000-\u200A\u202F\u205F\u3000]
+Zs =
+    [\u0020\u00A0\u1680\u2000-\u200A\u202F\u205F\u3000]
 
-LineTerminator
-  = [\n\r\u2028\u2029]
+LineTerminator =
+    [\n\r\u2028\u2029]
 
-LineTerminatorSequence "end of line"
-  = "\n"
-  / "\r\n"
-  / "\r"
-  / "\u2028"
-  / "\u2029"
+LineTerminatorSequence "end of line" =
+    "\n"
+    / "\r\n"
+    / "\r"
+    / "\u2028"
+    / "\u2029"
 
 __
-  = (WhiteSpace / LineTerminator)*
+    = (WhiteSpace / LineTerminator)*
 
 IMPORT = "import"
 AS = "as"
 FROM = "from"
-SEMI = ";"
-STAR = "*"
+SEMICOLON = ";"
+ASTERISK = "*"
 LBRACE = "{"
 RBRACE = "}"
 COMMA = ","
 
-StringLiteral
-    = "'" chars: SingleStringChar* "'" { return chars.join(""); }
+StringLiteral =
+    "'" chars: SingleStringChar* "'" { return chars.join(""); }
     / '"' chars: DoubleStringChar* '"' { return chars.join(""); }
 
-AnyChar
-    = .
+AnyChar =
+    .
 
-DoubleStringChar
-    = !('"' / "\\" / LineTerminator) AnyChar { return text(); }
+DoubleStringChar =
+    !('"' / "\\" / LineTerminator) AnyChar { return text(); }
     / "\\" sequence: EscapeSequence { return sequence; }
     / LineContinuation
 
-SingleStringChar
-    = !("'" / "\\" / LineTerminator) AnyChar { return text(); }
+SingleStringChar =
+    !("'" / "\\" / LineTerminator) AnyChar { return text(); }
     / "\\" sequence: EscapeSequence { return sequence; }
     / LineContinuation
 
-LineContinuation
-    = "\\" LineTerminatorSequence { return ""; }
+LineContinuation =
+    "\\" LineTerminatorSequence { return ""; }
 
-EscapeSequence
-    = CharEscapeSequence
+EscapeSequence =
+    CharEscapeSequence
     / "0" !DecDigit { return "\0"; }
     / HexEscapeSequence
     / UnicodeEscapeSequence
 
-CharEscapeSequence
-    = SingleEscapeChar
+CharEscapeSequence =
+    SingleEscapeChar
     / NonEscapeChar
 
-SingleEscapeChar
-    = "'"
+SingleEscapeChar =
+    "'"
     / '"'
     / "\\"
     / "b"  { return "\b"; }
@@ -83,41 +84,62 @@ SingleEscapeChar
     / "t"  { return "\t"; }
     / "v"  { return "\v"; }
 
-NonEscapeChar
-    = !(EscapeChar / LineTerminator) AnyChar { return text(); }
+NonEscapeChar =
+    !(EscapeChar / LineTerminator) AnyChar { return text(); }
 
-HexDigit
-    = [0-9a-f]i
+HexDigit =
+    [0-9a-f]i
 
-DecDigit
-    = [0-9]
+DecDigit =
+    [0-9]
 
-EscapeChar
-    = SingleEscapeChar
+EscapeChar =
+    SingleEscapeChar
     / DecDigit
     / "x"
     / "u"
 
-HexEscapeSequence
-    = "x" digits:$(HexDigit HexDigit) { return String.fromCharCode(parseInt(digits, 16)); }
+HexEscapeSequence =
+    "x" digits:$(HexDigit HexDigit) {
+        return String.fromCharCode(parseInt(digits, 16));
+    }
 
-UnicodeEscapeSequence
-    = "u" digits:$(HexDigit HexDigit HexDigit HexDigit) { return String.fromCharCode(parseInt(digits, 16)); }
+UnicodeEscapeSequence =
+    "u" digits:$(HexDigit HexDigit HexDigit HexDigit) {
+        return String.fromCharCode(parseInt(digits, 16));
+    }
 
 Identifier =
-    id:([a-zA-Z_][a-zA-Z0-9_]*) {return text(); }
+    id: ([a-zA-Z_][a-zA-Z0-9_]*) { return text(); }
 
 Symbol = 
-    name: (Identifier) alias: (__ AS __ Identifier)? { return { name, alias: alias[3] } as SymbolDesc }
+    name: (Identifier) alias: (__ AS __ Identifier)? {
+        return { name, alias: alias[3] } as SymbolDesc
+    }
 
 SymbolList =
     head: Symbol
     tail: ( __ COMMA __ Symbol)* {
-        return tail.reduce((acc, el) => { acc.push(el[3]); return acc; }, [head])
+        return tail.reduce(
+            (acc, el) => {
+                acc.push(el[3]);
+                
+                return acc;
+            },
+            [head]
+        );
     }
 
-ImportDirective
-    = IMPORT __ path: StringLiteral __ SEMI { return { path, unitAlias: undefined, symbolAliases: [] } as ImportDirectiveDesc; }
-    / IMPORT __ path: StringLiteral __ AS __ unitAlias: Identifier __ SEMI { return { path, unitAlias, symbolAliases: [] } as ImportDirectiveDesc; }
-    / IMPORT __ STAR __ AS __ unitAlias: Identifier __ FROM __ path: StringLiteral __ SEMI { return { path, unitAlias, symbolAliases: [] } as ImportDirectiveDesc; }
-    / IMPORT __ LBRACE __ symbolAliases: SymbolList __ RBRACE __ FROM __ path: StringLiteral __ SEMI { return { symbolAliases, path, unitAlias: undefined } as ImportDirectiveDesc; }
+ImportDirective =
+    IMPORT __ path: StringLiteral __ SEMICOLON {
+        return { path, unitAlias: undefined, symbolAliases: [] } as ImportDirectiveDesc;
+    }
+    / IMPORT __ path: StringLiteral __ AS __ unitAlias: Identifier __ SEMICOLON {
+        return { path, unitAlias, symbolAliases: [] } as ImportDirectiveDesc;
+    }
+    / IMPORT __ ASTERISK __ AS __ unitAlias: Identifier __ FROM __ path: StringLiteral __ SEMICOLON {
+        return { path, unitAlias, symbolAliases: [] } as ImportDirectiveDesc;
+    }
+    / IMPORT __ LBRACE __ symbolAliases: SymbolList __ RBRACE __ FROM __ path: StringLiteral __ SEMICOLON {
+        return { symbolAliases, path, unitAlias: undefined } as ImportDirectiveDesc;
+    }

--- a/src/spec-lang/expr_grammar.pegjs
+++ b/src/spec-lang/expr_grammar.pegjs
@@ -285,11 +285,11 @@ DecDigit =
 ExponentIndicator =
     "e" / "E"
 
-SignedInteger
-    = [+-]? DecDigit+
+SignedInteger =
+    [+-]? DecDigit+
 
-ExponentPart
-    = ExponentIndicator SignedInteger
+ExponentPart =
+    ExponentIndicator SignedInteger
 
 DecNumber =
     DecDigit+ ExponentPart? {

--- a/src/spec-lang/expr_grammar.pegjs
+++ b/src/spec-lang/expr_grammar.pegjs
@@ -30,10 +30,7 @@ AnnotationLabel =
     "{:msg" __  str: AnnotationStr __ "}" { return str; }
 
 Invariant =
-    type: INVARIANT
-    __ label: AnnotationLabel?
-    __ expr: Expression
-    __ ";" {
+    type: INVARIANT __ label: AnnotationLabel? __ expr: Expression __ ";" {
         return new SProperty(
             type as AnnotationType,
             expr,
@@ -48,14 +45,7 @@ Range =
 
 
 For_All =
-    type: FORALL
-    __ "("
-    __ itr_type: IntType
-    __ iterator: Identifier
-    __ IN
-    __ range: Range
-    __ ")"
-    __ expr: Expression {
+    type: FORALL __ "(" __ itr_type: IntType __ iterator: Identifier __ IN __ range: Range __ ")" __ expr: Expression {
         if (Array.isArray(range)) {
             const [start, end] = range;
 
@@ -66,10 +56,7 @@ For_All =
     }
 
 If_Succeeds =
-    type: IF_SUCCEEDS
-    __ label: AnnotationLabel?
-    __ expr: Expression
-    __ ";" {
+    type: IF_SUCCEEDS __ label: AnnotationLabel? __ expr: Expression __ ";" {
         return new SProperty(
             type as AnnotationType,
             expr,
@@ -90,10 +77,7 @@ IndexPath =
 // TODO: Eventually remove hacky '/' from if_updated rule. This is to work around
 // limitations in Solidity - it throws if it sees natspec on internal state vars
 If_Updated =
-    ("/" __)?
-    type: IF_UPDATED
-    __ label: AnnotationLabel?
-    __ expr: Expression __ ";" {
+    ("/" __)? type: IF_UPDATED __ label: AnnotationLabel? __ expr: Expression __ ";" {
         return new SIfUpdated(
             expr,
             [],
@@ -103,11 +87,7 @@ If_Updated =
     }
 
 If_Assigned =
-    ("/" __)?
-    type: IF_ASSIGNED
-    path: IndexPath
-    __ label: AnnotationLabel?
-    __ expr: Expression __ ";" {
+    ("/" __)? type: IF_ASSIGNED path: IndexPath __ label: AnnotationLabel? __ expr: Expression __ ";" {
         return new SIfAssigned(
             expr,
             path,
@@ -138,13 +118,7 @@ TypedArgs =
     }
 
 UserFunctionDefinition =
-    type: DEFINE
-    __ label: AnnotationLabel?
-    __ name: Identifier
-    __ "(" __ args: TypedArgs? __ ")"
-    __ returnType: Type
-    __ "="
-    __ body: Expression {
+    type: DEFINE __ label: AnnotationLabel? __ name: Identifier __ "(" __ args: TypedArgs? __ ")" __ returnType: Type __ "=" __ body: Expression {
         return new SUserFunctionDefinition(
             name,
             args === null ? [] : args,
@@ -156,6 +130,7 @@ UserFunctionDefinition =
     }
 
 // Terminals
+
 PrimitiveWhiteSpace "whitespace" =
     "\t"
     / "\v"
@@ -173,6 +148,7 @@ StartingWhiteSpace "whitespace" =
     PrimitiveWhiteSpace* LineTerminator? PrimitiveWhiteSpace* ("*" / "///")? __
 
 // Separator, Space
+
 Zs =
     [\u0020\u00A0\u1680\u2000-\u200A\u202F\u205F\u3000]
 
@@ -510,9 +486,7 @@ BitwiseORExpression =
 
 RelationalExpression =
     (
-        left: BitwiseORExpression
-        __ op: RelationalOperator
-        __ right: BitwiseORExpression {
+        left: BitwiseORExpression __ op: RelationalOperator __ right: BitwiseORExpression {
             return new SBinaryOperation(left, op as RleationalBinaryOperator, right, location());
         }
     )
@@ -608,7 +582,7 @@ AddressType =
     }
 
 IntType =
-    unsigned: ("u"?) "int" width:(Number?) {
+    unsigned: ("u"?) "int" width: (Number?) {
         const isSigned = unsigned === null;
         const bitWidth = width === null ? 256 : width.num.toJSNumber();
 
@@ -717,10 +691,7 @@ FunctionDecoratorList =
     }
 
 FunctionType =
-    FUNCTION
-    __ "(" __ args: TypeList? __ ")"
-    __ decorators: (FunctionDecoratorList?)
-    __ returns: (RETURNS __ "(" __ (TypeList) __ ")")? {
+    FUNCTION __ "(" __ args: TypeList? __ ")" __ decorators: (FunctionDecoratorList?) __ returns: (RETURNS __ "(" __ (TypeList) __ ")")? {
         const argTs = args === null ? [] : args;
         const retTs = returns === null ? [] : returns[4];
         const decoratorsList = decorators === null ? [] : decorators;

--- a/src/spec-lang/expr_grammar.pegjs
+++ b/src/spec-lang/expr_grammar.pegjs
@@ -1,18 +1,20 @@
 // Top-level rules
-Annotation
-    = StartingWhiteSpace
-      prefix: '#'?
-      annotation: (
+
+Annotation =
+    StartingWhiteSpace
+    prefix: '#'?
+    annotation: (
         Invariant
         / If_Succeeds
         / If_Updated
         / If_Assigned
         / UserFunctionDefinition
-      ) .* {
+    )
+    .* {
         annotation.prefix = prefix === null ? undefined : prefix;
 
         return annotation;
-      }
+    }
 
 Expression =
     For_All
@@ -20,107 +22,172 @@ Expression =
 
 // Non-top-level rules
 
-AnnotationStr
-    = "'" chars: SingleStringChar* "'" { return chars.join("") }
-    / '"' chars: DoubleStringChar* '"' { return chars.join("") }
-AnnotationLabel = "{:msg" __  str:AnnotationStr __ "}" { return str; }
+AnnotationStr =
+    "'" chars: SingleStringChar* "'" { return chars.join(""); }
+    / '"' chars: DoubleStringChar* '"' { return chars.join(""); }
 
-TypedArgs =
-    head: (typ: Type __ name: Identifier { return [name, typ]; })
-    tail: (__ "," __ typ: Type __ name: Identifier {return [name, typ]; })*
-    {
-        return tail.reduce((acc, el) => {acc.push(el); return acc; }, [head]);
-    }
+AnnotationLabel =
+    "{:msg" __  str: AnnotationStr __ "}" { return str; }
 
 Invariant =
-  type: INVARIANT __ label: AnnotationLabel? __ expr: Expression __ ";"
-  {
-    return new SProperty(type as AnnotationType, expr, label !== null ? label : undefined, location());
-  }
+    type: INVARIANT
+    __ label: AnnotationLabel?
+    __ expr: Expression
+    __ ";" {
+        return new SProperty(
+            type as AnnotationType,
+            expr,
+            label === null ? undefined : label,
+            location()
+        );
+    }
 
 Range =
-    start: Expression __ "..."  __ end: Expression
-    {
-      return [start, end];
-    }
-    / expression: Expression {return expression;}
+    start: Expression __ "..."  __ end: Expression { return [start, end]; }
+    / expression: Expression { return expression; }
 
 
 For_All =
-  type: FORALL __ "(" __ itr_type: IntType __ iterator: Identifier __ IN __ range: Range __ ")" __ expr: Expression
-  {
-    if(Array.isArray(range)) {
-      const [start, end] = range;
-      return new SForAll(itr_type, iterator, expr, start, end, undefined, location());
+    type: FORALL
+    __ "("
+    __ itr_type: IntType
+    __ iterator: Identifier
+    __ IN
+    __ range: Range
+    __ ")"
+    __ expr: Expression {
+        if (Array.isArray(range)) {
+            const [start, end] = range;
+
+            return new SForAll(itr_type, iterator, expr, start, end, undefined, location());
+        }
+
+        return new SForAll(itr_type, iterator, expr, undefined, undefined, range, location());
     }
-    else {
-      return new SForAll(itr_type, iterator, expr, undefined, undefined, range, location());
-    }
-  }
 
 If_Succeeds =
-  type: IF_SUCCEEDS __ label: AnnotationLabel? __ expr: Expression __ ";"
-  {
-    return new SProperty(type as AnnotationType, expr, label !== null ? label : undefined, location());
-  }
+    type: IF_SUCCEEDS
+    __ label: AnnotationLabel?
+    __ expr: Expression
+    __ ";" {
+        return new SProperty(
+            type as AnnotationType,
+            expr,
+            label === null ? undefined : label,
+            location()
+        );
+    }
 
-DatastructurePath_Index = "[" __ id: Identifier __"]" { return id; }
-DatastructurePath_Field = "." id: Identifier {return id.name;}
-IndexPath = (DatastructurePath_Field / DatastructurePath_Index)*
+DatastructurePath_Index =
+    "[" __ id: Identifier __"]" { return id; }
+
+DatastructurePath_Field =
+    "." id: Identifier { return id.name; }
+
+IndexPath =
+    (DatastructurePath_Field / DatastructurePath_Index)*
 
 // TODO: Eventually remove hacky '/' from if_updated rule. This is to work around
 // limitations in Solidity - it throws if it sees natspec on internal state vars
 If_Updated =
-  ("/" __)? type: IF_UPDATED __ label: AnnotationLabel? __ expr: Expression __ ";"
-  {
-    return new SIfUpdated(expr, [], label !== null ? label : undefined, location());
-  }
+    ("/" __)?
+    type: IF_UPDATED
+    __ label: AnnotationLabel?
+    __ expr: Expression __ ";" {
+        return new SIfUpdated(
+            expr,
+            [],
+            label === null ? undefined : label,
+            location()
+        );
+    }
 
 If_Assigned =
-  ("/" __)? type: IF_ASSIGNED path: IndexPath __ label: AnnotationLabel? __ expr: Expression __ ";"
-  {
-    return new SIfAssigned(expr, path, label !== null ? label : undefined, location());
-  }
+    ("/" __)?
+    type: IF_ASSIGNED
+    path: IndexPath
+    __ label: AnnotationLabel?
+    __ expr: Expression __ ";" {
+        return new SIfAssigned(
+            expr,
+            path,
+            label === null ? undefined : label,
+            location()
+        );
+    }
 
-UserFunctionDefinition = 
-  type: DEFINE __ label: AnnotationLabel? __ name: Identifier __ "(" __ args: TypedArgs? __ ")" __ returnType: Type __ "=" __ body: Expression
-  {
-    return new SUserFunctionDefinition(name, args === null ? [] : args, returnType, body, label !== null ? label : undefined, location());
-  }
+TypedArgs =
+    head: (
+        type: Type __ name: Identifier {
+            return [name, type];
+        }
+    )
+    tail: (
+        __ "," __ type: Type __ name: Identifier {
+            return [name, type];
+        }
+    )* {
+        return tail.reduce(
+            (acc, el) => {
+                acc.push(el);
+                
+                return acc;
+            },
+            [head]
+        );
+    }
+
+UserFunctionDefinition =
+    type: DEFINE
+    __ label: AnnotationLabel?
+    __ name: Identifier
+    __ "(" __ args: TypedArgs? __ ")"
+    __ returnType: Type
+    __ "="
+    __ body: Expression {
+        return new SUserFunctionDefinition(
+            name,
+            args === null ? [] : args,
+            returnType,
+            body,
+            label === null ? undefined : label,
+            location()
+        );
+    }
 
 // Terminals
+PrimitiveWhiteSpace "whitespace" =
+    "\t"
+    / "\v"
+    / "\f"
+    / " "
+    / "\u00A0"
+    / "\uFEFF"
+    / Zs
 
-PrimitiveWhiteSpace "whitespace"
-  = "\t"
-  / "\v"
-  / "\f"
-  / " "
-  / "\u00A0"
-  / "\uFEFF"
-  / Zs
+WhiteSpace "whitespace" =
+    PrimitiveWhiteSpace
+    / LineTerminator PrimitiveWhiteSpace* ("*" / "///")
 
-WhiteSpace "whitespace"
-  = PrimitiveWhiteSpace
-  / LineTerminator PrimitiveWhiteSpace* ("*" / "///")
-
-StartingWhiteSpace "whitespace"
-  = PrimitiveWhiteSpace* LineTerminator? PrimitiveWhiteSpace* ("*" / "///")? __ 
+StartingWhiteSpace "whitespace" =
+    PrimitiveWhiteSpace* LineTerminator? PrimitiveWhiteSpace* ("*" / "///")? __
 
 // Separator, Space
-Zs = [\u0020\u00A0\u1680\u2000-\u200A\u202F\u205F\u3000]
+Zs =
+    [\u0020\u00A0\u1680\u2000-\u200A\u202F\u205F\u3000]
 
-LineTerminator
-  = [\n\r\u2028\u2029]
+LineTerminator =
+    [\n\r\u2028\u2029]
 
-LineTerminatorSequence "end of line"
-  = "\n"
-  / "\r\n"
-  / "\r"
-  / "\u2028"
-  / "\u2029"
+LineTerminatorSequence "end of line" =
+    "\n"
+    / "\r\n"
+    / "\r"
+    / "\u2028"
+    / "\u2029"
 
-__
-  = (WhiteSpace / LineTerminator)*
+__ =
+    (WhiteSpace / LineTerminator)*
 
 TRUE = "true"
 FALSE = "false"
@@ -153,8 +220,8 @@ IF_ASSIGNED = "if_assigned"
 DEFINE = "define"
 FORALL = "forall"
 
-Keyword
-    = TRUE
+Keyword =
+    TRUE
     / FALSE
     / OLD
     / LET
@@ -180,96 +247,117 @@ Keyword
     / RESULT
     / FORALL
 
-// Number units
-NumberUnit = 'wei' / 'gwei' / 'ether' / 'seconds' 
-          / 'minutes' / 'hours' / 'days' / 'weeks'
+NumberUnit =
+    "wei"
+    / "gwei"
+    / "ether"
+    / "seconds"
+    / "minutes"
+    / "hours"
+    / "days"
+    / "weeks"
 
 // expression
 
 Identifier =
-    !(Keyword ![a-zA-Z0-9_]) id:([a-zA-Z_][a-zA-Z0-9_]*) {return new SId(text(), location());}
+    !(Keyword ![a-zA-Z0-9_]) id:([a-zA-Z_][a-zA-Z0-9_]*) {
+        return new SId(text(), location());
+    }
 
-HexDigit
-    = [0-9a-f]i
+HexDigit =
+    [0-9a-f]i
 
 HexNumber =
     "0x"i digits: HexDigit+ {
-      const num = digits.join('');
+        const num = digits.join('');
 
-      // 20-byte hex literals are implicitly treated as address constants.
-      if (digits.length === 40) {
-        return new SAddressLiteral('0x' + num, location())
-      } else {
-        return new SNumber(bigInt(num, 16), 16, location())
-      }
+        // 20-byte hex literals are implicitly treated as address constants.
+        if (digits.length === 40) {
+            return new SAddressLiteral('0x' + num, location());
+        }
+
+        return new SNumber(bigInt(num, 16), 16, location());
     }
 
-DecDigit
-    = [0-9]
+DecDigit =
+    [0-9]
 
-ExponentIndicator
-  = "e"i
+ExponentIndicator =
+    "e" / "E"
 
 SignedInteger
-  = [+-]? DecDigit+
+    = [+-]? DecDigit+
 
 ExponentPart
     = ExponentIndicator SignedInteger
 
 DecNumber =
-    DecDigit+ ExponentPart? { return new SNumber(bigInt(text()), 10, location()); }
+    DecDigit+ ExponentPart? {
+        return new SNumber(bigInt(text()), 10, location());
+    }
 
 Number =
-    value: (HexNumber / DecNumber) unit: (__ NumberUnit)? 
-    { 
-      if(unit == null) return value
+    value: (HexNumber / DecNumber) unit: (__ NumberUnit)? {
+        if (unit === null) {
+            return value;
+        }
 
-      if (value instanceof SAddressLiteral || value.radix == 16) {
-          throw new Error(`Cannot use units with hex literals`);
-      }
-      
-      return new SNumber(bigInt(value.num), value.radix, location(), unit[1])
+        if (value instanceof SAddressLiteral || value.radix === 16) {
+            throw new Error(`Cannot use units with hex literals`);
+        }
+
+        return new SNumber(bigInt(value.num), value.radix, location(), unit[1]);
     }
 
 BooleanLiteral =
-    val: (TRUE / FALSE) { return new SBooleanLiteral(text() == "true", location())}
+    val: (TRUE / FALSE) {
+        return new SBooleanLiteral(text() === "true", location());
+    }
 
-HexLiteral
-    = HEX '"' val: HexDigit* '"' { return new SHexLiteral(val.join(""), location()) }
-    / HEX "'" val: HexDigit* "'" { return new SHexLiteral(val.join(""), location()) }
+HexLiteral =
+    HEX '"' val: HexDigit* '"' {
+        return new SHexLiteral(val.join(""), location());
+    }
+    / HEX "'" val: HexDigit* "'" {
+        return new SHexLiteral(val.join(""), location());
+    }
 
-StringLiteral
-    = "'" chars: SingleStringChar* "'" { return new SStringLiteral(chars.join(""), location()) }
-    / '"' chars: DoubleStringChar* '"' { return new SStringLiteral(chars.join(""), location()) }
+StringLiteral =
+    "'" chars: SingleStringChar* "'" {
+        return new SStringLiteral(chars.join(""), location());
+    }
+    / '"' chars: DoubleStringChar* '"' {
+        return new SStringLiteral(chars.join(""), location());
+    }
 
-AnyChar
-    = .
+AnyChar =
+    .
 
-DoubleStringChar
-    = !('"' / "\\" / LineTerminator) AnyChar { return text(); }
+DoubleStringChar =
+    !('"' / "\\" / LineTerminator) AnyChar { return text(); }
     / "\\" sequence: EscapeSequence { return sequence; }
     / LineContinuation
 
-SingleStringChar
-    = !("'" / "\\" / LineTerminator) AnyChar { return text(); }
+SingleStringChar =
+    !("'" / "\\" / LineTerminator) AnyChar { return text(); }
     / "\\" sequence: EscapeSequence { return sequence; }
     / LineContinuation
 
-LineContinuation
-    = "\\" LineTerminatorSequence { return ""; }
+LineContinuation =
+    "\\" LineTerminatorSequence { return ""; }
 
-EscapeSequence
-    = CharEscapeSequence
+EscapeSequence =
+    CharEscapeSequence
     / "0" !DecDigit { return "\0"; }
     / HexEscapeSequence
     / UnicodeEscapeSequence
 
-CharEscapeSequence
-    = SingleEscapeChar
+CharEscapeSequence =
+    SingleEscapeChar
     / NonEscapeChar
 
-SingleEscapeChar
-    = "'"
+SingleEscapeChar =
+    "'"
     / '"'
     / "\\"
     / "b"  { return "\b"; }
@@ -279,233 +367,366 @@ SingleEscapeChar
     / "t"  { return "\t"; }
     / "v"  { return "\v"; }
 
-NonEscapeChar
-    = !(EscapeChar / LineTerminator) AnyChar { return text(); }
+NonEscapeChar =
+    !(EscapeChar / LineTerminator) AnyChar { return text(); }
 
-EscapeChar
-    = SingleEscapeChar
+EscapeChar =
+    SingleEscapeChar
     / DecDigit
     / "x"
     / "u"
 
-HexEscapeSequence
-    = "x" digits:$(HexDigit HexDigit) { return String.fromCharCode(parseInt(digits, 16)); }
+HexEscapeSequence =
+    "x" digits: $(HexDigit HexDigit) {
+        return String.fromCharCode(parseInt(digits, 16));
+    }
 
 UnicodeEscapeSequence
-    = "u" digits:$(HexDigit HexDigit HexDigit HexDigit) { return String.fromCharCode(parseInt(digits, 16)); }
+    = "u" digits: $(HexDigit HexDigit HexDigit HexDigit) {
+        return String.fromCharCode(parseInt(digits, 16));
+    }
 
 PrimaryExpression =
-    HexLiteral / Identifier / Number / BooleanLiteral / StringLiteral / ("(" __ expr: Expression __ ")" { return expr; }) / (RESULT {return new SResult(location());})
+    HexLiteral
+    / Identifier
+    / Number
+    / BooleanLiteral
+    / StringLiteral
+    / (
+        "(" __ expr: Expression __ ")" { return expr; }
+    )
+    / (RESULT { return new SResult(location()); })
 
-OldExpression
-= OLD __ "(" __ expr: Expression __ ")" { return new SUnaryOperation("old", expr, location()); }
-  / PrimaryExpression
+OldExpression =
+    OLD __ "(" __ expr: Expression __ ")" {
+        return new SUnaryOperation("old", expr, location());
+    }
+    / PrimaryExpression
 
 MemberAccessExpression =
     head: (OldExpression / Type)
     tail: (
-        __ "." __ property: Identifier { return {property: property };}
-      / __ "[" __ index: Expression __ "]" { return {index: index };}
-      / "(" __ args: ArgumentList? __ ")" { return {callArgs: args} ; }
+        __ "." __ property: Identifier { return { property: property }; }
+        / __ "[" __ index: Expression __ "]" { return { index: index }; }
+        / "(" __ args: ArgumentList? __ ")" { return { args: args } ; }
     )* {
-      return tail.reduce(
-        (acc, el) => {
-          if (el.hasOwnProperty("index")) {
-            return new SIndexAccess(acc, el.index, location());
-          } else if (el.hasOwnProperty("property")) {
-            return new SMemberAccess(acc, el.property.name, location());
-          } else {
-            const args = el.callArgs === null ? [] : el.callArgs;
-            return new SFunctionCall(acc, args, location());
-          }
-        },
-        head
-      )
+        return tail.reduce(
+            (acc, el) => {
+                if (el.hasOwnProperty("index")) {
+                    return new SIndexAccess(acc, el.index, location());
+                }
+
+                if (el.hasOwnProperty("property")) {
+                    return new SMemberAccess(acc, el.property.name, location());
+                }
+
+                const args = el.args === null ? [] : el.args;
+
+                return new SFunctionCall(acc, args, location());
+            },
+            head
+        );
     }
 
 ArgumentList =
     head: (Expression)
-    tail: (__ "," __ expr: Expression)*
-    {
-      return tail.reduce((acc, el) => { acc.push(el[3]); return acc; }, [head]);
+    tail: (__ "," __ expr: Expression)* {
+        return tail.reduce(
+            (acc, el) => {
+                acc.push(el[3]);
+
+                return acc;
+            },
+            [head]
+        );
     }
 
 UnaryExpression =
-    (operator: UnaryOperator __ subexp: UnaryExpression {
-        return new SUnaryOperation(operator as UnaryOperator, subexp, location());
-    })
+    (
+        operator: UnaryOperator __ subexp: UnaryExpression {
+            return new SUnaryOperation(operator as UnaryOperator, subexp, location());
+        }
+    )
     / MemberAccessExpression
 
 UnaryOperator =
-    "-" / "!"
+    "-"
+    / "!"
 
-PowerExpression
-  = head: UnaryExpression
+PowerExpression =
+    head: UnaryExpression
     tail: (__ op: "**" __ UnaryExpression)* {
         return buildBinaryExpression(head, tail, location());
     }
 
-MultiplicativeOperator
-  = $("*") { return text() as MultiplicativeBinaryOperator; }
-  / $("/") { return text() as MultiplicativeBinaryOperator; }
-  / $("%") { return text() as MultiplicativeBinaryOperator; }
+MultiplicativeOperator =
+    $("*") { return text() as MultiplicativeBinaryOperator; }
+    / $("/") { return text() as MultiplicativeBinaryOperator; }
+    / $("%") { return text() as MultiplicativeBinaryOperator; }
 
-MultiplicativeExpression
-  = head: PowerExpression
+MultiplicativeExpression =
+    head: PowerExpression
     tail: (__ op: MultiplicativeOperator __ PowerExpression)* {
         return buildBinaryExpression(head, tail, location());
     }
 
-AdditiveOperator
-  = $("+") { return text() as AdditiveBinaryOperator; }
-  / $("-") { return text() as AdditiveBinaryOperator; }
+AdditiveOperator =
+    $("+") { return text() as AdditiveBinaryOperator; }
+    / $("-") { return text() as AdditiveBinaryOperator; }
 
-AdditiveExpression
-  = head:MultiplicativeExpression
-    tail:(__ AdditiveOperator __ MultiplicativeExpression)*
-    { return buildBinaryExpression(head, tail, location()); }
+AdditiveExpression =
+    head: MultiplicativeExpression
+    tail: (__ AdditiveOperator __ MultiplicativeExpression)* {
+        return buildBinaryExpression(head, tail, location());
+    }
 
-ShiftExpression
-  = head:AdditiveExpression
-    tail:(__ ShiftOperator __ AdditiveExpression)*
-    { return buildBinaryExpression(head, tail, location()); }
+ShiftExpression =
+    head: AdditiveExpression
+    tail: (__ ShiftOperator __ AdditiveExpression)* {
+        return buildBinaryExpression(head, tail, location());
+    }
 
-ShiftOperator
-  = $("<<") { return text() as ShiftBinaryOperator; } 
-  / $(">>") { return text() as ShiftBinaryOperator; }
+ShiftOperator =
+    $("<<") { return text() as ShiftBinaryOperator; }
+    / $(">>") { return text() as ShiftBinaryOperator; }
 
-BitwiseANDExpression
-  = head:ShiftExpression
-    tail:(__ "&" __ ShiftExpression)*
-    { return buildBinaryExpression(head, tail, location()); }
+BitwiseANDExpression =
+    head: ShiftExpression
+    tail: (__ "&" __ ShiftExpression)* {
+        return buildBinaryExpression(head, tail, location());
+    }
 
-BitwiseXORExpression
-  = head:BitwiseANDExpression
-    tail:(__ "^" __ BitwiseANDExpression)*
-    { return buildBinaryExpression(head, tail, location()); }
+BitwiseXORExpression =
+    head: BitwiseANDExpression
+    tail: (__ "^" __ BitwiseANDExpression)* {
+        return buildBinaryExpression(head, tail, location());
+    }
 
-BitwiseORExpression
-  = head:BitwiseXORExpression
-    tail:(__ "|" __ BitwiseXORExpression)*
-    { return buildBinaryExpression(head, tail, location()); }
+BitwiseORExpression =
+    head: BitwiseXORExpression
+    tail: (__ "|" __ BitwiseXORExpression)* {
+        return buildBinaryExpression(head, tail, location());
+    }
 
-RelationalExpression
-  = (left: BitwiseORExpression __ op: RelationalOperator __ right: BitwiseORExpression { return new SBinaryOperation(left, op as RleationalBinaryOperator, right, location()); }) 
-  / BitwiseORExpression
+RelationalExpression =
+    (
+        left: BitwiseORExpression
+        __ op: RelationalOperator
+        __ right: BitwiseORExpression {
+            return new SBinaryOperation(left, op as RleationalBinaryOperator, right, location());
+        }
+    )
+    / BitwiseORExpression
 
-RelationalOperator
-  = '<=' { return text(); }
-  / '>=' { return text(); }
-  / '<' { return text(); }
-  / '>' { return text(); }
+RelationalOperator =
+    '<=' { return text(); }
+    / '>=' { return text(); }
+    / '<' { return text(); }
+    / '>' { return text(); }
 
-EqualityExpression
-  = head:RelationalExpression
-    tail:(__ EqualityOperator __ RelationalExpression)*
-    { return buildBinaryExpression(head, tail, location()); }
-  
-EqualityOperator
-  = "==" { return text(); }
-  / "!=" { return text(); }
+EqualityExpression =
+    head: RelationalExpression
+    tail: (__ EqualityOperator __ RelationalExpression)* {
+        return buildBinaryExpression(head, tail, location());
+    }
 
-LogicalANDExpression
-  = head:EqualityExpression
-    tail:(__ "&&" __ EqualityExpression)*
-    { return buildBinaryExpression(head, tail, location()); }
+EqualityOperator =
+    "==" { return text(); }
+    / "!=" { return text(); }
 
-LogicalORExpression
-  = head:LogicalANDExpression
-    tail:(__ "||" __ LogicalANDExpression)*
-    { return buildBinaryExpression(head, tail, location()); }
+LogicalANDExpression =
+    head: EqualityExpression
+    tail: (__ "&&" __ EqualityExpression)* {
+        return buildBinaryExpression(head, tail, location());
+    }
 
-ImplicationExpression
-  = precedent: LogicalORExpression 
-    tail: (__ "==>" __  ImplicationExpression)*
-    { return buildBinaryExpression(precedent, tail, location()); }
+LogicalORExpression =
+    head: LogicalANDExpression
+    tail: (__ "||" __ LogicalANDExpression)* {
+        return buildBinaryExpression(head, tail, location());
+    }
+
+ImplicationExpression =
+    precedent: LogicalORExpression
+    tail: (__ "==>" __  ImplicationExpression)* {
+        return buildBinaryExpression(precedent, tail, location());
+    }
 
 ConditionalExpression =
     head: ImplicationExpression
-    tail: (__ "?" __ trueE: Expression __ ":" __ falseE: Expression { return [trueE, falseE]; })*
-    {
-      return tail.reduce(
-        (acc, [trueE, falseE]) => {
-          return new SConditional(acc, trueE, falseE, location());
-        },
-        head
-      )
+    tail: (
+        __ "?" __ trueExpr: Expression __ ":" __ falseExpr: Expression {
+            return [trueExpr, falseExpr];
+        }
+    )* {
+        return tail.reduce(
+            (acc, [trueExpr, falseExpr]) => new SConditional(acc, trueExpr, falseExpr, location()),
+            head
+        )
     }
-  
-LetExpression
-  = LET __ bindings:LhsBindings __ ":=" __ rhs: Expression __ IN __ inExp:Expression { return new SLet(bindings, rhs, inExp, location()); }
-  / ConditionalExpression
 
-LhsBindings
-  = head: Identifier __ tail:("," __ id: Identifier __ { return id; })* { return tail.reduce((acc, cur) => {acc.push(cur); return acc;}, [head]); }
+LetExpression =
+    LET __ bindings: LhsBindings __ ":=" __ rhs: Expression __ IN __ inExpr: Expression {
+        return new SLet(bindings, rhs, inExpr, location());
+    }
+    / ConditionalExpression
 
-Type = FunctionType
+LhsBindings =
+    head: Identifier __ tail: ("," __ id: Identifier __ { return id; })* {
+        return tail.reduce(
+            (acc, cur) => {
+                acc.push(cur);
+                
+                return acc;
+            },
+            [head]
+        );
+    }
 
-SimpleType
-  = BoolType
-  / AddressType
-  / IntType
-  / BytesType
-  / FixedSizeBytesType
-  / StringType
-  / UserDefinedType
+// Types
 
-BoolType = BOOL { return new BoolType(location()) }
-AddressType = ADDRESS __ payable:(PAYABLE?) { return new AddressType(payable !== null, location())}
-IntType = unsigned:("u"?) "int" width:(Number?) { 
-  const signed = unsigned === null;
-  const bitWidth = width === null ? 256 : width.num.toJSNumber();
-  return new IntType(bitWidth, signed, location());
-}
-FixedSizeBytesType
-  = BYTES width:Number { return new FixedBytesType(width, location()); }
-  / BYTE { return new FixedBytesType(1, location()); }
+Type =
+    FunctionType
 
-BytesType = BYTES !Number { return new BytesType(location()); }
-StringType = STRING { return new StringType(location()); }
+SimpleType =
+    BoolType
+    / AddressType
+    / IntType
+    / BytesType
+    / FixedSizeBytesType
+    / StringType
+    / UserDefinedType
 
-UserDefinedType
-  = base: Identifier "." field: Identifier { return makeUserDefinedType(name, options, location()); }
-  / name: Identifier  { return makeUserDefinedType(name, options, location()); }
+BoolType =
+    BOOL {
+        return new BoolType(location())
+    }
 
-ArrayType
-  = head: SimpleType tail: ( __ "[" __ size: Number? __ "]")* {
-    return tail.reduce((acc, cur) => {
-      const size = cur[3];
-      return new ArrayType(acc, size !== null ? BigInt(size.num.toJSNumber()) : undefined, location());
-    }, head)
-  }
+AddressType =
+    ADDRESS __ payable:(PAYABLE?) {
+        return new AddressType(payable !== null, location());
+    }
 
-MappingType
-  = MAPPING __ "(" __ keyType: SimpleType __ "=>" __ valueType: MappingType __ ")" { return new MappingType(keyType, valueType, location()); }
-  / ArrayType
+IntType =
+    unsigned: ("u"?) "int" width:(Number?) {
+        const isSigned = unsigned === null;
+        const bitWidth = width === null ? 256 : width.num.toJSNumber();
 
-DataLocation = MEMORY / STORAGE / CALLDATA
-PointerType = toType: MappingType __ location: (DataLocation?) {
-  return location === null ? toType : new PointerType(toType, location as DataLocation, undefined, location());
-}
+        return new IntType(bitWidth, isSigned, location());
+    }
 
-TypeList
-  = head: PointerType tail: (__ "," __ PointerType)* { return tail.reduce((acc, cur)=> { acc.push(cur[3]); return acc; }, [head]) }
+FixedSizeBytesType =
+    BYTES width: Number {
+        return new FixedBytesType(width, location());
+    }
+    / BYTE {
+        return new FixedBytesType(1, location());
+    }
 
+BytesType =
+    BYTES !Number {
+        return new BytesType(location());
+    }
 
-FunctionVisibility = EXTERNAL / INTERNAL
-FunctionMutability = PURE / VIEW / PAYABLE / NONPAYABLE
-FunctionDecorator = FunctionVisibility / FunctionMutability
+StringType =
+    STRING {
+        return new StringType(location());
+    }
 
-FunctionDecoratorList
-  = head: FunctionDecorator tail: (__ FunctionDecorator)* { return tail.reduce((acc, cur) => { acc.push(cur[1]); return acc}, [head])}
+UserDefinedType =
+    base: Identifier "." field: Identifier {
+        return makeUserDefinedType(name, options, location());
+    }
+    / name: Identifier {
+        return makeUserDefinedType(name, options, location());
+    }
 
-FunctionType
-  = FUNCTION __ "(" __ args: TypeList? __ ")" __ decorators: (FunctionDecoratorList?) __ returns:(RETURNS __ "(" __ (TypeList) __ ")")? {
-    const argTs = args === null ? [] : args;
-    const retTs = returns === null ? [] : returns[4];
-    decorators = decorators === null ? [] : decorators;
+ArrayType =
+    head: SimpleType
+    tail: ( __ "[" __ size: Number? __ "]")* {
+        return tail.reduce(
+            (acc, cur) => {
+                const size = cur[3];
 
-    const [visibility, mutability] = getFunctionAttrbiutes(decorators);
-    return new FunctionType(undefined, argTs, retTs, visibility, mutability, location());
-  }
-  / PointerType
+                return new ArrayType(
+                    acc,
+                    size === null ? undefined : BigInt(size.num.toJSNumber()),
+                    location()
+                );
+            },
+            head
+        )
+    }
+
+MappingType =
+    MAPPING __ "(" __ keyType: SimpleType __ "=>" __ valueType: MappingType __ ")" {
+        return new MappingType(keyType, valueType, location());
+    }
+    / ArrayType
+
+DataLocation =
+    MEMORY
+    / STORAGE
+    / CALLDATA
+
+PointerType =
+    toType: MappingType __ dataLocation: (DataLocation?) {
+        return dataLocation === null
+            ? toType
+            : new PointerType(toType, dataLocation as DataLocation, undefined, location());
+    }
+
+TypeList =
+    head: PointerType
+    tail: (__ "," __ PointerType)* {
+        return tail.reduce(
+            (acc, cur) => {
+                acc.push(cur[3]);
+                
+                return acc;
+            },
+            [head]
+        );
+    }
+
+FunctionVisibility =
+    EXTERNAL
+    / INTERNAL
+
+FunctionMutability =
+    PURE
+    / VIEW
+    / PAYABLE
+    / NONPAYABLE
+
+FunctionDecorator =
+    FunctionVisibility
+    / FunctionMutability
+
+FunctionDecoratorList =
+    head: FunctionDecorator
+    tail: (__ FunctionDecorator)* {
+        return tail.reduce(
+            (acc, cur) => {
+                acc.push(cur[1]);
+
+                return acc;
+            },
+            [head]
+        )
+    }
+
+FunctionType =
+    FUNCTION
+    __ "(" __ args: TypeList? __ ")"
+    __ decorators: (FunctionDecoratorList?)
+    __ returns: (RETURNS __ "(" __ (TypeList) __ ")")? {
+        const argTs = args === null ? [] : args;
+        const retTs = returns === null ? [] : returns[4];
+        const decoratorsList = decorators === null ? [] : decorators;
+
+        const [visibility, mutability] = getFunctionAttrbiutes(decoratorsList);
+
+        return new FunctionType(undefined, argTs, retTs, visibility, mutability, location());
+    }
+    / PointerType


### PR DESCRIPTION
## Premise
For last few weeks Scribble received several bigger updates, that were affecting grammar. We figured out that it would be simplier to improve grammars to make overall style a bit more readable for a future changes.

## Changes
Tweaked `import_directive.pegjs` and `expr_grammar.pegjs`:
- [x] Tweaked indentation to consistently use 4 spaces instead of mixed `2` or `4`.
- [x] Reduced nesting in macros.
- [x] Conditional (ternary) operations in macros are now using same style `x === null ? undefined : x` instead of mixed cases.
- [x] Equality sign now always appear in same line as the rule name. Rule definition is staring on the next line (except `Keyword`s section).

Regards.