### PR TITLE
Add support for --compiler-settings command line option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -311,9 +311,9 @@
             }
         },
         "@ethersproject/bignumber": {
-            "version": "5.4.1",
-            "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.1.tgz",
-            "integrity": "sha512-fJhdxqoQNuDOk6epfM7yD6J8Pol4NUCy1vkaGAkuujZm0+lNow//MKu1hLhRiYV4BsOHyBv5/lsTjF+7hWwhJg==",
+            "version": "5.4.2",
+            "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.2.tgz",
+            "integrity": "sha512-oIBDhsKy5bs7j36JlaTzFgNPaZjiNDOXsdSgSpXRucUl+UA6L/1YLlFeI3cPAoodcenzF4nxNPV13pcy7XbWjA==",
             "requires": {
                 "@ethersproject/bytes": "^5.4.0",
                 "@ethersproject/logger": "^5.4.0",
@@ -5483,10 +5483,10 @@
                 }
             }
         },
-        "solc-0.4.14": {
-            "version": "npm:solc@0.4.14",
-            "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.14.tgz",
-            "integrity": "sha1-phS7zxWYOePwIh0cQbudq53Hg/4=",
+        "solc-0.4.13": {
+            "version": "npm:solc@0.4.13",
+            "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.13.tgz",
+            "integrity": "sha1-qly9zOPmrjwZDSD1/fi8iAcC7HU=",
             "requires": {
                 "fs-extra": "^0.30.0",
                 "memorystream": "^0.3.1",
@@ -5523,9 +5523,9 @@
             }
         },
         "solc-typed-ast": {
-            "version": "6.1.1",
-            "resolved": "https://registry.npmjs.org/solc-typed-ast/-/solc-typed-ast-6.1.1.tgz",
-            "integrity": "sha512-ueD8KcbCAgpF1F1JWSKMY8lIwU01hL4srxviYGOFcfqLy4+tFzOpYW3Iix/v+xc35LWPTaxUdBXZaG0h+Y1K8g==",
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/solc-typed-ast/-/solc-typed-ast-6.1.2.tgz",
+            "integrity": "sha512-63p/hpH8Vs3HKQYUdxsMhHtVnavfD7M/YaYjPvE2IX5SWL59lsjo5ptIlqUKhVsjF9nbTmauDOftTuQf0yrPtQ==",
             "requires": {
                 "findup-sync": "^4.0.0",
                 "fs-extra": "^10.0.0",
@@ -5686,10 +5686,10 @@
                     "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
                     "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
                 },
-                "solc-0.4.13": {
-                    "version": "npm:solc@0.4.13",
-                    "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.13.tgz",
-                    "integrity": "sha1-qly9zOPmrjwZDSD1/fi8iAcC7HU=",
+                "solc-0.4.14": {
+                    "version": "npm:solc@0.4.14",
+                    "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.14.tgz",
+                    "integrity": "sha1-phS7zxWYOePwIh0cQbudq53Hg/4=",
                     "requires": {
                         "fs-extra": "^0.30.0",
                         "memorystream": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "fs-extra": "^10.0.0",
         "logplease": "^1.2.15",
         "semver": "^7.3.5",
-        "solc-typed-ast": "^6.1.1",
+        "solc-typed-ast": "^6.1.2",
         "src-location": "^1.1.0"
     },
     "scripts": {

--- a/src/bin/scribble.ts
+++ b/src/bin/scribble.ts
@@ -799,7 +799,8 @@ if ("version" in options) {
                         `flattened.sol`,
                         flatContents,
                         version,
-                        pathRemapping
+                        pathRemapping,
+                        compilerSettings
                     );
                 } catch (e) {
                     if (e instanceof CompileFailedError) {

--- a/src/bin/scribble_cli.json
+++ b/src/bin/scribble_cli.json
@@ -73,6 +73,11 @@
                 "description": "If given, specifies the exact compiler version to use"
             },
             {
+                "name": "compiler-settings",
+                "type": "String",
+                "description": "If given, specifies additional settings to pass to the underlying compiler as a JSON string. (e.g. --compiler-settings '\\{\"optimizer:\": \\{\"enabled\": true\\}\\}'). For more info see https://docs.soliditylang.org/en/latest/using-the-compiler.html#input-description"
+            },
+            {
                 "name": "no-assert",
                 "type": "Boolean",
                 "description": "If specified execution will not halt when an invariant is violated (only an event will be emitted)."


### PR DESCRIPTION
This PR:

1. Add support for `--compiler-settings` command line option. This options allows for a user to pass arbitrary settings to the Solidity compiler as a JSON string. (e.g. `--compiler-settings '{"optimizer": {"enabled": true, "runs": 200}}'` (note the use of single and double quotes). For more info see https://docs.soliditylang.org/en/latest/using-the-compiler.html#input-description. (Fixes #77)

2. Fixes a bug when merging multiple pragmas in flat mode. If we have pragmas with the same id in multiple files, then after flattening we would have multiple pragmas for the same id in the flat file, which causing compiler failures (this happens for example with `pragma experimental ABIEncoderV2`).