### PR TITLE
Change scribble to not always generate bytecode when compiling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1270,6 +1270,11 @@
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
             "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
+        "command-exists": {
+            "version": "1.2.9",
+            "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
+            "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
+        },
         "command-line-args": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.1.tgz",
@@ -1303,6 +1308,11 @@
                     "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
                 }
             }
+        },
+        "commander": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
+            "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
         },
         "commondir": {
             "version": "1.0.1",
@@ -1538,6 +1548,11 @@
                 "minimalistic-assert": "^1.0.1",
                 "minimalistic-crypto-utils": "^1.0.1"
             }
+        },
+        "emoji-regex": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+            "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
         },
         "encoding-down": {
             "version": "5.0.4",
@@ -2230,6 +2245,20 @@
                 "safe-buffer": "^5.1.1"
             }
         },
+        "execa": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+            "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+            "requires": {
+                "cross-spawn": "^6.0.0",
+                "get-stream": "^4.0.0",
+                "is-stream": "^1.1.0",
+                "npm-run-path": "^2.0.0",
+                "p-finally": "^1.0.0",
+                "signal-exit": "^3.0.0",
+                "strip-eof": "^1.0.0"
+            }
+        },
         "expand-tilde": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
@@ -2414,6 +2443,11 @@
             "resolved": "https://registry.npmjs.org/flow-stoplight/-/flow-stoplight-1.0.0.tgz",
             "integrity": "sha1-SiksW8/4s5+mzAyxqFPYbyfu/3s=",
             "dev": true
+        },
+        "follow-redirects": {
+            "version": "1.14.4",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
+            "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g=="
         },
         "foreground-child": {
             "version": "2.0.0",
@@ -3418,6 +3452,17 @@
                 "universalify": "^2.0.0"
             }
         },
+        "keccak": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+            "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+            "requires": {
+                "bindings": "^1.2.1",
+                "inherits": "^2.0.3",
+                "nan": "^2.2.1",
+                "safe-buffer": "^5.1.0"
+            }
+        },
         "klaw": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
@@ -3711,6 +3756,22 @@
                 "strip-bom": "^2.0.0"
             }
         },
+        "locate-path": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+            "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+            "requires": {
+                "p-locate": "^2.0.0",
+                "path-exists": "^3.0.0"
+            },
+            "dependencies": {
+                "path-exists": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+                }
+            }
+        },
         "lodash": {
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -3877,6 +3938,16 @@
                 "hash-base": "^3.0.0",
                 "inherits": "^2.0.1",
                 "safe-buffer": "^5.1.2"
+            }
+        },
+        "mem": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+            "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
+            "requires": {
+                "map-age-cleaner": "^0.1.1",
+                "mimic-fn": "^2.0.0",
+                "p-is-promise": "^2.0.0"
             }
         },
         "memdown": {
@@ -5412,10 +5483,10 @@
                 }
             }
         },
-        "solc-0.4.13": {
-            "version": "npm:solc@0.4.13",
-            "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.13.tgz",
-            "integrity": "sha1-qly9zOPmrjwZDSD1/fi8iAcC7HU=",
+        "solc-0.4.16": {
+            "version": "npm:solc@0.4.16",
+            "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.16.tgz",
+            "integrity": "sha1-gJpbElfHwgDhGoQbN36uwnRphTk=",
             "requires": {
                 "fs-extra": "^0.30.0",
                 "memorystream": "^0.3.1",
@@ -5452,9 +5523,9 @@
             }
         },
         "solc-typed-ast": {
-            "version": "6.1.2",
-            "resolved": "https://registry.npmjs.org/solc-typed-ast/-/solc-typed-ast-6.1.2.tgz",
-            "integrity": "sha512-63p/hpH8Vs3HKQYUdxsMhHtVnavfD7M/YaYjPvE2IX5SWL59lsjo5ptIlqUKhVsjF9nbTmauDOftTuQf0yrPtQ==",
+            "version": "6.1.3",
+            "resolved": "https://registry.npmjs.org/solc-typed-ast/-/solc-typed-ast-6.1.3.tgz",
+            "integrity": "sha512-L1/qlvSxhyltguOjfFsnbbwxEMId+HdL0qw9YMbgx73G/dsIxGRjtesehuv7kvf6X67iDRxobgBTw6Nlhl2cLw==",
             "requires": {
                 "findup-sync": "^4.0.0",
                 "fs-extra": "^10.0.0",
@@ -5551,17 +5622,6 @@
                     "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
                     "requires": {
                         "locate-path": "^2.0.0"
-                    },
-                    "dependencies": {
-                        "locate-path": {
-                            "version": "2.0.0",
-                            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-                            "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-                            "requires": {
-                                "p-locate": "^2.0.0",
-                                "path-exists": "^3.0.0"
-                            }
-                        }
                     }
                 },
                 "invert-kv": {
@@ -5598,32 +5658,6 @@
                         "execa": "^1.0.0",
                         "lcid": "^2.0.0",
                         "mem": "^4.0.0"
-                    },
-                    "dependencies": {
-                        "execa": {
-                            "version": "1.0.0",
-                            "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-                            "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-                            "requires": {
-                                "cross-spawn": "^6.0.0",
-                                "get-stream": "^4.0.0",
-                                "is-stream": "^1.1.0",
-                                "npm-run-path": "^2.0.0",
-                                "p-finally": "^1.0.0",
-                                "signal-exit": "^3.0.0",
-                                "strip-eof": "^1.0.0"
-                            }
-                        },
-                        "mem": {
-                            "version": "4.3.0",
-                            "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
-                            "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
-                            "requires": {
-                                "map-age-cleaner": "^0.1.1",
-                                "mimic-fn": "^2.0.0",
-                                "p-is-promise": "^2.0.0"
-                            }
-                        }
                     }
                 },
                 "p-limit": {
@@ -5632,6 +5666,14 @@
                     "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
                     "requires": {
                         "p-try": "^2.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+                    "requires": {
+                        "p-limit": "^2.0.0"
                     }
                 },
                 "p-try": {
@@ -5643,6 +5685,37 @@
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
                     "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+                },
+                "solc-0.4.13": {
+                    "version": "npm:solc@0.4.13",
+                    "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.13.tgz",
+                    "integrity": "sha1-qly9zOPmrjwZDSD1/fi8iAcC7HU=",
+                    "requires": {
+                        "fs-extra": "^0.30.0",
+                        "memorystream": "^0.3.1",
+                        "require-from-string": "^1.1.0",
+                        "semver": "^5.3.0",
+                        "yargs": "^4.7.1"
+                    },
+                    "dependencies": {
+                        "fs-extra": {
+                            "version": "0.30.0",
+                            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+                            "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
+                            "requires": {
+                                "graceful-fs": "^4.1.2",
+                                "jsonfile": "^2.1.0",
+                                "klaw": "^1.0.0",
+                                "path-is-absolute": "^1.0.0",
+                                "rimraf": "^2.2.8"
+                            }
+                        },
+                        "semver": {
+                            "version": "5.7.1",
+                            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+                        }
+                    }
                 },
                 "solc-0.4.14": {
                     "version": "npm:solc@0.4.14",
@@ -5679,37 +5752,6 @@
                     "version": "npm:solc@0.4.15",
                     "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.15.tgz",
                     "integrity": "sha1-iujxYGoSSj+BwoudzssJZOvfnyU=",
-                    "requires": {
-                        "fs-extra": "^0.30.0",
-                        "memorystream": "^0.3.1",
-                        "require-from-string": "^1.1.0",
-                        "semver": "^5.3.0",
-                        "yargs": "^4.7.1"
-                    },
-                    "dependencies": {
-                        "fs-extra": {
-                            "version": "0.30.0",
-                            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
-                            "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
-                            "requires": {
-                                "graceful-fs": "^4.1.2",
-                                "jsonfile": "^2.1.0",
-                                "klaw": "^1.0.0",
-                                "path-is-absolute": "^1.0.0",
-                                "rimraf": "^2.2.8"
-                            }
-                        },
-                        "semver": {
-                            "version": "5.7.1",
-                            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                        }
-                    }
-                },
-                "solc-0.4.16": {
-                    "version": "npm:solc@0.4.16",
-                    "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.16.tgz",
-                    "integrity": "sha1-gJpbElfHwgDhGoQbN36uwnRphTk=",
                     "requires": {
                         "fs-extra": "^0.30.0",
                         "memorystream": "^0.3.1",
@@ -6072,17 +6114,6 @@
                                 "rimraf": "^2.2.8"
                             }
                         },
-                        "keccak": {
-                            "version": "1.4.0",
-                            "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-                            "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-                            "requires": {
-                                "bindings": "^1.2.1",
-                                "inherits": "^2.0.3",
-                                "nan": "^2.2.1",
-                                "safe-buffer": "^5.1.0"
-                            }
-                        },
                         "require-from-string": {
                             "version": "2.0.2",
                             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -6129,11 +6160,6 @@
                         "yargs": "^11.0.0"
                     },
                     "dependencies": {
-                        "command-exists": {
-                            "version": "1.2.9",
-                            "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-                            "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
-                        },
                         "fs-extra": {
                             "version": "0.30.0",
                             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -6146,17 +6172,6 @@
                                 "rimraf": "^2.2.8"
                             }
                         },
-                        "keccak": {
-                            "version": "1.4.0",
-                            "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-                            "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-                            "requires": {
-                                "bindings": "^1.2.1",
-                                "inherits": "^2.0.3",
-                                "nan": "^2.2.1",
-                                "safe-buffer": "^5.1.0"
-                            }
-                        },
                         "require-from-string": {
                             "version": "2.0.2",
                             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -6166,14 +6181,6 @@
                             "version": "5.7.1",
                             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                        },
-                        "tmp": {
-                            "version": "0.0.33",
-                            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-                            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-                            "requires": {
-                                "os-tmpdir": "~1.0.2"
-                            }
                         },
                         "yargs": {
                             "version": "11.1.1",
@@ -6211,11 +6218,6 @@
                         "yargs": "^11.0.0"
                     },
                     "dependencies": {
-                        "command-exists": {
-                            "version": "1.2.9",
-                            "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-                            "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
-                        },
                         "fs-extra": {
                             "version": "0.30.0",
                             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -6228,17 +6230,6 @@
                                 "rimraf": "^2.2.8"
                             }
                         },
-                        "keccak": {
-                            "version": "1.4.0",
-                            "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-                            "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-                            "requires": {
-                                "bindings": "^1.2.1",
-                                "inherits": "^2.0.3",
-                                "nan": "^2.2.1",
-                                "safe-buffer": "^5.1.0"
-                            }
-                        },
                         "require-from-string": {
                             "version": "2.0.2",
                             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -6248,14 +6239,6 @@
                             "version": "5.7.1",
                             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                        },
-                        "tmp": {
-                            "version": "0.0.33",
-                            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-                            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-                            "requires": {
-                                "os-tmpdir": "~1.0.2"
-                            }
                         },
                         "yargs": {
                             "version": "11.1.1",
@@ -6313,16 +6296,6 @@
                                 "wrap-ansi": "^5.1.0"
                             }
                         },
-                        "command-exists": {
-                            "version": "1.2.9",
-                            "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-                            "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
-                        },
-                        "emoji-regex": {
-                            "version": "7.0.3",
-                            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-                            "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
-                        },
                         "find-up": {
                             "version": "3.0.0",
                             "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -6357,14 +6330,6 @@
                                 "path-exists": "^3.0.0"
                             }
                         },
-                        "p-locate": {
-                            "version": "3.0.0",
-                            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-                            "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-                            "requires": {
-                                "p-limit": "^2.0.0"
-                            }
-                        },
                         "require-from-string": {
                             "version": "2.0.2",
                             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -6396,14 +6361,6 @@
                             "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
                             "requires": {
                                 "ansi-regex": "^4.1.0"
-                            }
-                        },
-                        "tmp": {
-                            "version": "0.0.33",
-                            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-                            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-                            "requires": {
-                                "os-tmpdir": "~1.0.2"
                             }
                         },
                         "wrap-ansi": {
@@ -6484,16 +6441,6 @@
                                 "wrap-ansi": "^5.1.0"
                             }
                         },
-                        "command-exists": {
-                            "version": "1.2.9",
-                            "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-                            "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
-                        },
-                        "emoji-regex": {
-                            "version": "7.0.3",
-                            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-                            "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
-                        },
                         "find-up": {
                             "version": "3.0.0",
                             "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -6528,14 +6475,6 @@
                                 "path-exists": "^3.0.0"
                             }
                         },
-                        "p-locate": {
-                            "version": "3.0.0",
-                            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-                            "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-                            "requires": {
-                                "p-limit": "^2.0.0"
-                            }
-                        },
                         "require-from-string": {
                             "version": "2.0.2",
                             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -6567,14 +6506,6 @@
                             "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
                             "requires": {
                                 "ansi-regex": "^4.1.0"
-                            }
-                        },
-                        "tmp": {
-                            "version": "0.0.33",
-                            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-                            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-                            "requires": {
-                                "os-tmpdir": "~1.0.2"
                             }
                         },
                         "wrap-ansi": {
@@ -6635,16 +6566,6 @@
                         "tmp": "0.0.33"
                     },
                     "dependencies": {
-                        "command-exists": {
-                            "version": "1.2.9",
-                            "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-                            "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
-                        },
-                        "commander": {
-                            "version": "3.0.2",
-                            "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-                            "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
-                        },
                         "fs-extra": {
                             "version": "0.30.0",
                             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -6666,14 +6587,6 @@
                             "version": "5.7.1",
                             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                        },
-                        "tmp": {
-                            "version": "0.0.33",
-                            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-                            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-                            "requires": {
-                                "os-tmpdir": "~1.0.2"
-                            }
                         }
                     }
                 },
@@ -6692,16 +6605,6 @@
                         "tmp": "0.0.33"
                     },
                     "dependencies": {
-                        "command-exists": {
-                            "version": "1.2.9",
-                            "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-                            "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
-                        },
-                        "commander": {
-                            "version": "3.0.2",
-                            "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-                            "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
-                        },
                         "fs-extra": {
                             "version": "0.30.0",
                             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -6723,14 +6626,6 @@
                             "version": "5.7.1",
                             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                        },
-                        "tmp": {
-                            "version": "0.0.33",
-                            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-                            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-                            "requires": {
-                                "os-tmpdir": "~1.0.2"
-                            }
                         }
                     }
                 },
@@ -6749,16 +6644,6 @@
                         "tmp": "0.0.33"
                     },
                     "dependencies": {
-                        "command-exists": {
-                            "version": "1.2.9",
-                            "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-                            "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
-                        },
-                        "commander": {
-                            "version": "3.0.2",
-                            "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-                            "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
-                        },
                         "fs-extra": {
                             "version": "0.30.0",
                             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -6780,14 +6665,6 @@
                             "version": "5.7.1",
                             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                        },
-                        "tmp": {
-                            "version": "0.0.33",
-                            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-                            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-                            "requires": {
-                                "os-tmpdir": "~1.0.2"
-                            }
                         }
                     }
                 },
@@ -6806,16 +6683,6 @@
                         "tmp": "0.0.33"
                     },
                     "dependencies": {
-                        "command-exists": {
-                            "version": "1.2.9",
-                            "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-                            "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
-                        },
-                        "commander": {
-                            "version": "3.0.2",
-                            "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-                            "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
-                        },
                         "fs-extra": {
                             "version": "0.30.0",
                             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -6837,14 +6704,6 @@
                             "version": "5.7.1",
                             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                        },
-                        "tmp": {
-                            "version": "0.0.33",
-                            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-                            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-                            "requires": {
-                                "os-tmpdir": "~1.0.2"
-                            }
                         }
                     }
                 },
@@ -6863,16 +6722,6 @@
                         "tmp": "0.0.33"
                     },
                     "dependencies": {
-                        "command-exists": {
-                            "version": "1.2.9",
-                            "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-                            "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
-                        },
-                        "commander": {
-                            "version": "3.0.2",
-                            "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-                            "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
-                        },
                         "fs-extra": {
                             "version": "0.30.0",
                             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -6894,14 +6743,6 @@
                             "version": "5.7.1",
                             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                        },
-                        "tmp": {
-                            "version": "0.0.33",
-                            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-                            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-                            "requires": {
-                                "os-tmpdir": "~1.0.2"
-                            }
                         }
                     }
                 },
@@ -6920,11 +6761,6 @@
                         "yargs": "^11.0.0"
                     },
                     "dependencies": {
-                        "command-exists": {
-                            "version": "1.2.9",
-                            "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-                            "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
-                        },
                         "fs-extra": {
                             "version": "0.30.0",
                             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -6937,17 +6773,6 @@
                                 "rimraf": "^2.2.8"
                             }
                         },
-                        "keccak": {
-                            "version": "1.4.0",
-                            "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-                            "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-                            "requires": {
-                                "bindings": "^1.2.1",
-                                "inherits": "^2.0.3",
-                                "nan": "^2.2.1",
-                                "safe-buffer": "^5.1.0"
-                            }
-                        },
                         "require-from-string": {
                             "version": "2.0.2",
                             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -6957,14 +6782,6 @@
                             "version": "5.7.1",
                             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                        },
-                        "tmp": {
-                            "version": "0.0.33",
-                            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-                            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-                            "requires": {
-                                "os-tmpdir": "~1.0.2"
-                            }
                         },
                         "yargs": {
                             "version": "11.1.1",
@@ -7002,11 +6819,6 @@
                         "yargs": "^11.0.0"
                     },
                     "dependencies": {
-                        "command-exists": {
-                            "version": "1.2.9",
-                            "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-                            "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
-                        },
                         "fs-extra": {
                             "version": "0.30.0",
                             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -7019,17 +6831,6 @@
                                 "rimraf": "^2.2.8"
                             }
                         },
-                        "keccak": {
-                            "version": "1.4.0",
-                            "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-                            "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-                            "requires": {
-                                "bindings": "^1.2.1",
-                                "inherits": "^2.0.3",
-                                "nan": "^2.2.1",
-                                "safe-buffer": "^5.1.0"
-                            }
-                        },
                         "require-from-string": {
                             "version": "2.0.2",
                             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -7039,14 +6840,6 @@
                             "version": "5.7.1",
                             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                        },
-                        "tmp": {
-                            "version": "0.0.33",
-                            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-                            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-                            "requires": {
-                                "os-tmpdir": "~1.0.2"
-                            }
                         },
                         "yargs": {
                             "version": "11.1.1",
@@ -7084,11 +6877,6 @@
                         "yargs": "^11.0.0"
                     },
                     "dependencies": {
-                        "command-exists": {
-                            "version": "1.2.9",
-                            "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-                            "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
-                        },
                         "fs-extra": {
                             "version": "0.30.0",
                             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -7101,17 +6889,6 @@
                                 "rimraf": "^2.2.8"
                             }
                         },
-                        "keccak": {
-                            "version": "1.4.0",
-                            "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-                            "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-                            "requires": {
-                                "bindings": "^1.2.1",
-                                "inherits": "^2.0.3",
-                                "nan": "^2.2.1",
-                                "safe-buffer": "^5.1.0"
-                            }
-                        },
                         "require-from-string": {
                             "version": "2.0.2",
                             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -7121,14 +6898,6 @@
                             "version": "5.7.1",
                             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                        },
-                        "tmp": {
-                            "version": "0.0.33",
-                            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-                            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-                            "requires": {
-                                "os-tmpdir": "~1.0.2"
-                            }
                         },
                         "yargs": {
                             "version": "11.1.1",
@@ -7166,11 +6935,6 @@
                         "yargs": "^11.0.0"
                     },
                     "dependencies": {
-                        "command-exists": {
-                            "version": "1.2.9",
-                            "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-                            "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
-                        },
                         "fs-extra": {
                             "version": "0.30.0",
                             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -7183,17 +6947,6 @@
                                 "rimraf": "^2.2.8"
                             }
                         },
-                        "keccak": {
-                            "version": "1.4.0",
-                            "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-                            "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-                            "requires": {
-                                "bindings": "^1.2.1",
-                                "inherits": "^2.0.3",
-                                "nan": "^2.2.1",
-                                "safe-buffer": "^5.1.0"
-                            }
-                        },
                         "require-from-string": {
                             "version": "2.0.2",
                             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -7203,14 +6956,6 @@
                             "version": "5.7.1",
                             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                        },
-                        "tmp": {
-                            "version": "0.0.33",
-                            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-                            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-                            "requires": {
-                                "os-tmpdir": "~1.0.2"
-                            }
                         },
                         "yargs": {
                             "version": "11.1.1",
@@ -7248,11 +6993,6 @@
                         "yargs": "^11.0.0"
                     },
                     "dependencies": {
-                        "command-exists": {
-                            "version": "1.2.9",
-                            "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-                            "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
-                        },
                         "fs-extra": {
                             "version": "0.30.0",
                             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -7265,17 +7005,6 @@
                                 "rimraf": "^2.2.8"
                             }
                         },
-                        "keccak": {
-                            "version": "1.4.0",
-                            "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-                            "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-                            "requires": {
-                                "bindings": "^1.2.1",
-                                "inherits": "^2.0.3",
-                                "nan": "^2.2.1",
-                                "safe-buffer": "^5.1.0"
-                            }
-                        },
                         "require-from-string": {
                             "version": "2.0.2",
                             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -7285,14 +7014,6 @@
                             "version": "5.7.1",
                             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                        },
-                        "tmp": {
-                            "version": "0.0.33",
-                            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-                            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-                            "requires": {
-                                "os-tmpdir": "~1.0.2"
-                            }
                         },
                         "yargs": {
                             "version": "11.1.1",
@@ -7330,11 +7051,6 @@
                         "yargs": "^11.0.0"
                     },
                     "dependencies": {
-                        "command-exists": {
-                            "version": "1.2.9",
-                            "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-                            "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
-                        },
                         "fs-extra": {
                             "version": "0.30.0",
                             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -7347,17 +7063,6 @@
                                 "rimraf": "^2.2.8"
                             }
                         },
-                        "keccak": {
-                            "version": "1.4.0",
-                            "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-                            "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-                            "requires": {
-                                "bindings": "^1.2.1",
-                                "inherits": "^2.0.3",
-                                "nan": "^2.2.1",
-                                "safe-buffer": "^5.1.0"
-                            }
-                        },
                         "require-from-string": {
                             "version": "2.0.2",
                             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -7367,14 +7072,6 @@
                             "version": "5.7.1",
                             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                        },
-                        "tmp": {
-                            "version": "0.0.33",
-                            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-                            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-                            "requires": {
-                                "os-tmpdir": "~1.0.2"
-                            }
                         },
                         "yargs": {
                             "version": "11.1.1",
@@ -7412,11 +7109,6 @@
                         "yargs": "^11.0.0"
                     },
                     "dependencies": {
-                        "command-exists": {
-                            "version": "1.2.9",
-                            "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-                            "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
-                        },
                         "fs-extra": {
                             "version": "0.30.0",
                             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -7429,17 +7121,6 @@
                                 "rimraf": "^2.2.8"
                             }
                         },
-                        "keccak": {
-                            "version": "1.4.0",
-                            "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-                            "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-                            "requires": {
-                                "bindings": "^1.2.1",
-                                "inherits": "^2.0.3",
-                                "nan": "^2.2.1",
-                                "safe-buffer": "^5.1.0"
-                            }
-                        },
                         "require-from-string": {
                             "version": "2.0.2",
                             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -7449,14 +7130,6 @@
                             "version": "5.7.1",
                             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                        },
-                        "tmp": {
-                            "version": "0.0.33",
-                            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-                            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-                            "requires": {
-                                "os-tmpdir": "~1.0.2"
-                            }
                         },
                         "yargs": {
                             "version": "11.1.1",
@@ -7494,11 +7167,6 @@
                         "yargs": "^11.0.0"
                     },
                     "dependencies": {
-                        "command-exists": {
-                            "version": "1.2.9",
-                            "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-                            "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
-                        },
                         "fs-extra": {
                             "version": "0.30.0",
                             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -7511,17 +7179,6 @@
                                 "rimraf": "^2.2.8"
                             }
                         },
-                        "keccak": {
-                            "version": "1.4.0",
-                            "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-                            "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-                            "requires": {
-                                "bindings": "^1.2.1",
-                                "inherits": "^2.0.3",
-                                "nan": "^2.2.1",
-                                "safe-buffer": "^5.1.0"
-                            }
-                        },
                         "require-from-string": {
                             "version": "2.0.2",
                             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -7531,14 +7188,6 @@
                             "version": "5.7.1",
                             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                        },
-                        "tmp": {
-                            "version": "0.0.33",
-                            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-                            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-                            "requires": {
-                                "os-tmpdir": "~1.0.2"
-                            }
                         },
                         "yargs": {
                             "version": "11.1.1",
@@ -7576,16 +7225,6 @@
                         "tmp": "0.0.33"
                     },
                     "dependencies": {
-                        "command-exists": {
-                            "version": "1.2.9",
-                            "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-                            "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
-                        },
-                        "commander": {
-                            "version": "3.0.2",
-                            "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-                            "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
-                        },
                         "fs-extra": {
                             "version": "0.30.0",
                             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -7607,14 +7246,6 @@
                             "version": "5.7.1",
                             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                        },
-                        "tmp": {
-                            "version": "0.0.33",
-                            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-                            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-                            "requires": {
-                                "os-tmpdir": "~1.0.2"
-                            }
                         }
                     }
                 },
@@ -7633,16 +7264,6 @@
                         "tmp": "0.0.33"
                     },
                     "dependencies": {
-                        "command-exists": {
-                            "version": "1.2.9",
-                            "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-                            "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
-                        },
-                        "commander": {
-                            "version": "3.0.2",
-                            "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-                            "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
-                        },
                         "fs-extra": {
                             "version": "0.30.0",
                             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -7664,14 +7285,6 @@
                             "version": "5.7.1",
                             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                        },
-                        "tmp": {
-                            "version": "0.0.33",
-                            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-                            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-                            "requires": {
-                                "os-tmpdir": "~1.0.2"
-                            }
                         }
                     }
                 },
@@ -7690,16 +7303,6 @@
                         "tmp": "0.0.33"
                     },
                     "dependencies": {
-                        "command-exists": {
-                            "version": "1.2.9",
-                            "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-                            "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
-                        },
-                        "commander": {
-                            "version": "3.0.2",
-                            "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-                            "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
-                        },
                         "fs-extra": {
                             "version": "0.30.0",
                             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -7721,14 +7324,6 @@
                             "version": "5.7.1",
                             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                        },
-                        "tmp": {
-                            "version": "0.0.33",
-                            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-                            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-                            "requires": {
-                                "os-tmpdir": "~1.0.2"
-                            }
                         }
                     }
                 },
@@ -7747,16 +7342,6 @@
                         "tmp": "0.0.33"
                     },
                     "dependencies": {
-                        "command-exists": {
-                            "version": "1.2.9",
-                            "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-                            "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
-                        },
-                        "commander": {
-                            "version": "3.0.2",
-                            "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-                            "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
-                        },
                         "fs-extra": {
                             "version": "0.30.0",
                             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -7778,14 +7363,6 @@
                             "version": "5.7.1",
                             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                        },
-                        "tmp": {
-                            "version": "0.0.33",
-                            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-                            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-                            "requires": {
-                                "os-tmpdir": "~1.0.2"
-                            }
                         }
                     }
                 },
@@ -7804,16 +7381,6 @@
                         "tmp": "0.0.33"
                     },
                     "dependencies": {
-                        "command-exists": {
-                            "version": "1.2.9",
-                            "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-                            "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
-                        },
-                        "commander": {
-                            "version": "3.0.2",
-                            "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-                            "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
-                        },
                         "fs-extra": {
                             "version": "0.30.0",
                             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -7835,14 +7402,6 @@
                             "version": "5.7.1",
                             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                        },
-                        "tmp": {
-                            "version": "0.0.33",
-                            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-                            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-                            "requires": {
-                                "os-tmpdir": "~1.0.2"
-                            }
                         }
                     }
                 },
@@ -7861,16 +7420,6 @@
                         "tmp": "0.0.33"
                     },
                     "dependencies": {
-                        "command-exists": {
-                            "version": "1.2.9",
-                            "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-                            "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
-                        },
-                        "commander": {
-                            "version": "3.0.2",
-                            "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-                            "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
-                        },
                         "fs-extra": {
                             "version": "0.30.0",
                             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -7892,14 +7441,6 @@
                             "version": "5.7.1",
                             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                        },
-                        "tmp": {
-                            "version": "0.0.33",
-                            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-                            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-                            "requires": {
-                                "os-tmpdir": "~1.0.2"
-                            }
                         }
                     }
                 },
@@ -7918,16 +7459,6 @@
                         "tmp": "0.0.33"
                     },
                     "dependencies": {
-                        "command-exists": {
-                            "version": "1.2.9",
-                            "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-                            "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
-                        },
-                        "commander": {
-                            "version": "3.0.2",
-                            "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-                            "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
-                        },
                         "fs-extra": {
                             "version": "0.30.0",
                             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -7949,14 +7480,6 @@
                             "version": "5.7.1",
                             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                        },
-                        "tmp": {
-                            "version": "0.0.33",
-                            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-                            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-                            "requires": {
-                                "os-tmpdir": "~1.0.2"
-                            }
                         }
                     }
                 },
@@ -7975,16 +7498,6 @@
                         "tmp": "0.0.33"
                     },
                     "dependencies": {
-                        "command-exists": {
-                            "version": "1.2.9",
-                            "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-                            "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
-                        },
-                        "commander": {
-                            "version": "3.0.2",
-                            "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-                            "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
-                        },
                         "fs-extra": {
                             "version": "0.30.0",
                             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -8006,14 +7519,6 @@
                             "version": "5.7.1",
                             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                        },
-                        "tmp": {
-                            "version": "0.0.33",
-                            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-                            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-                            "requires": {
-                                "os-tmpdir": "~1.0.2"
-                            }
                         }
                     }
                 },
@@ -8032,16 +7537,6 @@
                         "tmp": "0.0.33"
                     },
                     "dependencies": {
-                        "command-exists": {
-                            "version": "1.2.9",
-                            "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-                            "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
-                        },
-                        "commander": {
-                            "version": "3.0.2",
-                            "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-                            "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
-                        },
                         "fs-extra": {
                             "version": "0.30.0",
                             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -8063,14 +7558,6 @@
                             "version": "5.7.1",
                             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                        },
-                        "tmp": {
-                            "version": "0.0.33",
-                            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-                            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-                            "requires": {
-                                "os-tmpdir": "~1.0.2"
-                            }
                         }
                     }
                 },
@@ -8089,16 +7576,6 @@
                         "tmp": "0.0.33"
                     },
                     "dependencies": {
-                        "command-exists": {
-                            "version": "1.2.9",
-                            "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-                            "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
-                        },
-                        "commander": {
-                            "version": "3.0.2",
-                            "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-                            "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
-                        },
                         "fs-extra": {
                             "version": "0.30.0",
                             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -8120,14 +7597,6 @@
                             "version": "5.7.1",
                             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                        },
-                        "tmp": {
-                            "version": "0.0.33",
-                            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-                            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-                            "requires": {
-                                "os-tmpdir": "~1.0.2"
-                            }
                         }
                     }
                 },
@@ -8146,16 +7615,6 @@
                         "tmp": "0.0.33"
                     },
                     "dependencies": {
-                        "command-exists": {
-                            "version": "1.2.9",
-                            "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-                            "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
-                        },
-                        "commander": {
-                            "version": "3.0.2",
-                            "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-                            "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
-                        },
                         "fs-extra": {
                             "version": "0.30.0",
                             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -8177,14 +7636,6 @@
                             "version": "5.7.1",
                             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                        },
-                        "tmp": {
-                            "version": "0.0.33",
-                            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-                            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-                            "requires": {
-                                "os-tmpdir": "~1.0.2"
-                            }
                         }
                     }
                 },
@@ -8203,16 +7654,6 @@
                         "tmp": "0.0.33"
                     },
                     "dependencies": {
-                        "command-exists": {
-                            "version": "1.2.9",
-                            "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-                            "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
-                        },
-                        "commander": {
-                            "version": "3.0.2",
-                            "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-                            "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
-                        },
                         "fs-extra": {
                             "version": "0.30.0",
                             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -8234,14 +7675,6 @@
                             "version": "5.7.1",
                             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                        },
-                        "tmp": {
-                            "version": "0.0.33",
-                            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-                            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-                            "requires": {
-                                "os-tmpdir": "~1.0.2"
-                            }
                         }
                     }
                 },
@@ -8260,16 +7693,6 @@
                         "tmp": "0.0.33"
                     },
                     "dependencies": {
-                        "command-exists": {
-                            "version": "1.2.9",
-                            "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-                            "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
-                        },
-                        "commander": {
-                            "version": "3.0.2",
-                            "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-                            "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
-                        },
                         "fs-extra": {
                             "version": "0.30.0",
                             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -8291,14 +7714,6 @@
                             "version": "5.7.1",
                             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                        },
-                        "tmp": {
-                            "version": "0.0.33",
-                            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-                            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-                            "requires": {
-                                "os-tmpdir": "~1.0.2"
-                            }
                         }
                     }
                 },
@@ -8318,21 +7733,6 @@
                         "tmp": "0.0.33"
                     },
                     "dependencies": {
-                        "command-exists": {
-                            "version": "1.2.9",
-                            "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-                            "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
-                        },
-                        "commander": {
-                            "version": "3.0.2",
-                            "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-                            "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
-                        },
-                        "follow-redirects": {
-                            "version": "1.14.4",
-                            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
-                            "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g=="
-                        },
                         "fs-extra": {
                             "version": "0.30.0",
                             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -8354,14 +7754,6 @@
                             "version": "5.7.1",
                             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                        },
-                        "tmp": {
-                            "version": "0.0.33",
-                            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-                            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-                            "requires": {
-                                "os-tmpdir": "~1.0.2"
-                            }
                         }
                     }
                 },
@@ -8381,21 +7773,6 @@
                         "tmp": "0.0.33"
                     },
                     "dependencies": {
-                        "command-exists": {
-                            "version": "1.2.9",
-                            "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-                            "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
-                        },
-                        "commander": {
-                            "version": "3.0.2",
-                            "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-                            "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
-                        },
-                        "follow-redirects": {
-                            "version": "1.14.4",
-                            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
-                            "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g=="
-                        },
                         "fs-extra": {
                             "version": "0.30.0",
                             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -8417,14 +7794,6 @@
                             "version": "5.7.1",
                             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                        },
-                        "tmp": {
-                            "version": "0.0.33",
-                            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-                            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-                            "requires": {
-                                "os-tmpdir": "~1.0.2"
-                            }
                         }
                     }
                 },
@@ -8444,21 +7813,6 @@
                         "tmp": "0.0.33"
                     },
                     "dependencies": {
-                        "command-exists": {
-                            "version": "1.2.9",
-                            "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-                            "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
-                        },
-                        "commander": {
-                            "version": "3.0.2",
-                            "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-                            "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
-                        },
-                        "follow-redirects": {
-                            "version": "1.14.4",
-                            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
-                            "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g=="
-                        },
                         "fs-extra": {
                             "version": "0.30.0",
                             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -8480,14 +7834,6 @@
                             "version": "5.7.1",
                             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                        },
-                        "tmp": {
-                            "version": "0.0.33",
-                            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-                            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-                            "requires": {
-                                "os-tmpdir": "~1.0.2"
-                            }
                         }
                     }
                 },
@@ -8507,21 +7853,6 @@
                         "tmp": "0.0.33"
                     },
                     "dependencies": {
-                        "command-exists": {
-                            "version": "1.2.9",
-                            "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-                            "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
-                        },
-                        "commander": {
-                            "version": "3.0.2",
-                            "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-                            "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
-                        },
-                        "follow-redirects": {
-                            "version": "1.14.4",
-                            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
-                            "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g=="
-                        },
                         "fs-extra": {
                             "version": "0.30.0",
                             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -8543,14 +7874,6 @@
                             "version": "5.7.1",
                             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                        },
-                        "tmp": {
-                            "version": "0.0.33",
-                            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-                            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-                            "requires": {
-                                "os-tmpdir": "~1.0.2"
-                            }
                         }
                     }
                 },
@@ -8570,21 +7893,6 @@
                         "tmp": "0.0.33"
                     },
                     "dependencies": {
-                        "command-exists": {
-                            "version": "1.2.9",
-                            "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-                            "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
-                        },
-                        "commander": {
-                            "version": "3.0.2",
-                            "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-                            "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
-                        },
-                        "follow-redirects": {
-                            "version": "1.14.4",
-                            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
-                            "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g=="
-                        },
                         "fs-extra": {
                             "version": "0.30.0",
                             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -8606,14 +7914,6 @@
                             "version": "5.7.1",
                             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                        },
-                        "tmp": {
-                            "version": "0.0.33",
-                            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-                            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-                            "requires": {
-                                "os-tmpdir": "~1.0.2"
-                            }
                         }
                     }
                 },
@@ -8633,21 +7933,6 @@
                         "tmp": "0.0.33"
                     },
                     "dependencies": {
-                        "command-exists": {
-                            "version": "1.2.9",
-                            "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-                            "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
-                        },
-                        "commander": {
-                            "version": "3.0.2",
-                            "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-                            "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
-                        },
-                        "follow-redirects": {
-                            "version": "1.14.4",
-                            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
-                            "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g=="
-                        },
                         "fs-extra": {
                             "version": "0.30.0",
                             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -8669,14 +7954,6 @@
                             "version": "5.7.1",
                             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                        },
-                        "tmp": {
-                            "version": "0.0.33",
-                            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-                            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-                            "requires": {
-                                "os-tmpdir": "~1.0.2"
-                            }
                         }
                     }
                 },
@@ -8696,21 +7973,6 @@
                         "tmp": "0.0.33"
                     },
                     "dependencies": {
-                        "command-exists": {
-                            "version": "1.2.9",
-                            "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-                            "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
-                        },
-                        "commander": {
-                            "version": "3.0.2",
-                            "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-                            "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
-                        },
-                        "follow-redirects": {
-                            "version": "1.14.4",
-                            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
-                            "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g=="
-                        },
                         "fs-extra": {
                             "version": "0.30.0",
                             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -8732,14 +7994,6 @@
                             "version": "5.7.1",
                             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                        },
-                        "tmp": {
-                            "version": "0.0.33",
-                            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-                            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-                            "requires": {
-                                "os-tmpdir": "~1.0.2"
-                            }
                         }
                     }
                 },
@@ -8759,21 +8013,6 @@
                         "tmp": "0.0.33"
                     },
                     "dependencies": {
-                        "command-exists": {
-                            "version": "1.2.9",
-                            "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-                            "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
-                        },
-                        "commander": {
-                            "version": "3.0.2",
-                            "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-                            "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
-                        },
-                        "follow-redirects": {
-                            "version": "1.14.4",
-                            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
-                            "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g=="
-                        },
                         "fs-extra": {
                             "version": "0.30.0",
                             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -8795,14 +8034,6 @@
                             "version": "5.7.1",
                             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                        },
-                        "tmp": {
-                            "version": "0.0.33",
-                            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-                            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-                            "requires": {
-                                "os-tmpdir": "~1.0.2"
-                            }
                         }
                     }
                 },
@@ -8822,21 +8053,6 @@
                         "tmp": "0.0.33"
                     },
                     "dependencies": {
-                        "command-exists": {
-                            "version": "1.2.9",
-                            "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-                            "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
-                        },
-                        "commander": {
-                            "version": "3.0.2",
-                            "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-                            "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
-                        },
-                        "follow-redirects": {
-                            "version": "1.14.4",
-                            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
-                            "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g=="
-                        },
                         "fs-extra": {
                             "version": "0.30.0",
                             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -8858,14 +8074,6 @@
                             "version": "5.7.1",
                             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                        },
-                        "tmp": {
-                            "version": "0.0.33",
-                            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-                            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-                            "requires": {
-                                "os-tmpdir": "~1.0.2"
-                            }
                         }
                     }
                 },
@@ -8885,21 +8093,6 @@
                         "tmp": "0.0.33"
                     },
                     "dependencies": {
-                        "command-exists": {
-                            "version": "1.2.9",
-                            "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-                            "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
-                        },
-                        "commander": {
-                            "version": "3.0.2",
-                            "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-                            "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
-                        },
-                        "follow-redirects": {
-                            "version": "1.14.4",
-                            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
-                            "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g=="
-                        },
                         "fs-extra": {
                             "version": "0.30.0",
                             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -8921,14 +8114,6 @@
                             "version": "5.7.1",
                             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                        },
-                        "tmp": {
-                            "version": "0.0.33",
-                            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-                            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-                            "requires": {
-                                "os-tmpdir": "~1.0.2"
-                            }
                         }
                     }
                 },
@@ -8948,21 +8133,6 @@
                         "tmp": "0.0.33"
                     },
                     "dependencies": {
-                        "command-exists": {
-                            "version": "1.2.9",
-                            "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-                            "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
-                        },
-                        "commander": {
-                            "version": "3.0.2",
-                            "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-                            "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
-                        },
-                        "follow-redirects": {
-                            "version": "1.14.4",
-                            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
-                            "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g=="
-                        },
                         "fs-extra": {
                             "version": "0.30.0",
                             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -8984,14 +8154,6 @@
                             "version": "5.7.1",
                             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                        },
-                        "tmp": {
-                            "version": "0.0.33",
-                            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-                            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-                            "requires": {
-                                "os-tmpdir": "~1.0.2"
-                            }
                         }
                     }
                 },
@@ -9011,21 +8173,6 @@
                         "tmp": "0.0.33"
                     },
                     "dependencies": {
-                        "command-exists": {
-                            "version": "1.2.9",
-                            "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-                            "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
-                        },
-                        "commander": {
-                            "version": "3.0.2",
-                            "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-                            "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
-                        },
-                        "follow-redirects": {
-                            "version": "1.14.4",
-                            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
-                            "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g=="
-                        },
                         "fs-extra": {
                             "version": "0.30.0",
                             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -9047,14 +8194,6 @@
                             "version": "5.7.1",
                             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                        },
-                        "tmp": {
-                            "version": "0.0.33",
-                            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-                            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-                            "requires": {
-                                "os-tmpdir": "~1.0.2"
-                            }
                         }
                     }
                 },
@@ -9074,21 +8213,6 @@
                         "tmp": "0.0.33"
                     },
                     "dependencies": {
-                        "command-exists": {
-                            "version": "1.2.9",
-                            "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-                            "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
-                        },
-                        "commander": {
-                            "version": "3.0.2",
-                            "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-                            "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
-                        },
-                        "follow-redirects": {
-                            "version": "1.14.4",
-                            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
-                            "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g=="
-                        },
                         "fs-extra": {
                             "version": "0.30.0",
                             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -9110,14 +8234,6 @@
                             "version": "5.7.1",
                             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                        },
-                        "tmp": {
-                            "version": "0.0.33",
-                            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-                            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-                            "requires": {
-                                "os-tmpdir": "~1.0.2"
-                            }
                         }
                     }
                 },
@@ -9137,21 +8253,6 @@
                         "tmp": "0.0.33"
                     },
                     "dependencies": {
-                        "command-exists": {
-                            "version": "1.2.9",
-                            "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-                            "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
-                        },
-                        "commander": {
-                            "version": "3.0.2",
-                            "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-                            "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
-                        },
-                        "follow-redirects": {
-                            "version": "1.14.4",
-                            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
-                            "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g=="
-                        },
                         "fs-extra": {
                             "version": "0.30.0",
                             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -9173,14 +8274,6 @@
                             "version": "5.7.1",
                             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                        },
-                        "tmp": {
-                            "version": "0.0.33",
-                            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-                            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-                            "requires": {
-                                "os-tmpdir": "~1.0.2"
-                            }
                         }
                     }
                 },
@@ -9200,21 +8293,6 @@
                         "tmp": "0.0.33"
                     },
                     "dependencies": {
-                        "command-exists": {
-                            "version": "1.2.9",
-                            "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-                            "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
-                        },
-                        "commander": {
-                            "version": "3.0.2",
-                            "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-                            "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
-                        },
-                        "follow-redirects": {
-                            "version": "1.14.4",
-                            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
-                            "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g=="
-                        },
                         "fs-extra": {
                             "version": "0.30.0",
                             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -9236,14 +8314,6 @@
                             "version": "5.7.1",
                             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                        },
-                        "tmp": {
-                            "version": "0.0.33",
-                            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-                            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-                            "requires": {
-                                "os-tmpdir": "~1.0.2"
-                            }
                         }
                     }
                 },
@@ -9361,9 +8431,9 @@
             }
         },
         "spdx-license-ids": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.8.tgz",
-            "integrity": "sha512-NDgA96EnaLSvtbM7trJj+t1LUR3pirkDCcz9nOUlPb5DMBGsH7oES6C3hs3j7R9oHEa1EMvReS/BUAIT5Tcr0g=="
+            "version": "3.0.10",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.10.tgz",
+            "integrity": "sha512-oie3/+gKf7QtpitB0LYLETe+k8SifzsX4KixvpOsbI6S0kRiRQ5MKOio8eMSAKQ17N06+wdEOXRiId+zOxo0hA=="
         },
         "sprintf-js": {
             "version": "1.0.3",
@@ -9642,6 +8712,14 @@
             "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
             "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
         },
+        "tmp": {
+            "version": "0.0.33",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+            "requires": {
+                "os-tmpdir": "~1.0.2"
+            }
+        },
         "to-fast-properties": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -9811,18 +8889,18 @@
             }
         },
         "web3-eth-abi": {
-            "version": "1.5.2",
-            "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.5.2.tgz",
-            "integrity": "sha512-P3bJbDR5wib4kWGfVeBKBVi27T+AiHy4EJxYM6SMNbpm3DboLDdisu9YBd6INMs8rzxgnprBbGmmyn4jKIDKAA==",
+            "version": "1.5.3",
+            "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.5.3.tgz",
+            "integrity": "sha512-i/qhuFsoNrnV130CSRYX/z4SlCfSQ4mHntti5yTmmQpt70xZKYZ57BsU0R29ueSQ9/P+aQrL2t2rqkQkAloUxg==",
             "requires": {
                 "@ethersproject/abi": "5.0.7",
-                "web3-utils": "1.5.2"
+                "web3-utils": "1.5.3"
             }
         },
         "web3-utils": {
-            "version": "1.5.2",
-            "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.2.tgz",
-            "integrity": "sha512-quTtTeQJHYSxAwIBOCGEcQtqdVcFWX6mCFNoqnp+mRbq+Hxbs8CGgO/6oqfBx4OvxIOfCpgJWYVHswRXnbEu9Q==",
+            "version": "1.5.3",
+            "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.3.tgz",
+            "integrity": "sha512-56nRgA+Ad9SEyCv39g36rTcr5fpsd4L9LgV3FK0aB66nAMazLAA6Qz4lH5XrUKPDyBIPGJIR+kJsyRtwcu2q1Q==",
             "requires": {
                 "bn.js": "^4.11.9",
                 "eth-lib": "0.2.8",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "fs-extra": "^10.0.0",
         "logplease": "^1.2.15",
         "semver": "^7.3.5",
-        "solc-typed-ast": "^6.1.2",
+        "solc-typed-ast": "^6.1.3",
         "src-location": "^1.1.0"
     },
     "scripts": {

--- a/src/bin/scribble.ts
+++ b/src/bin/scribble.ts
@@ -5,6 +5,7 @@ import {
     ASTContext,
     ASTNodeFactory,
     ASTReader,
+    CompilationOutput,
     CompileFailedError,
     compileJson,
     compileJsonData,
@@ -141,6 +142,13 @@ function compile(
     remapping: string[],
     compilerSettings: any
 ): CompileResult {
+    const astOnlyOutput = [
+        CompilationOutput.AST,
+        CompilationOutput.ABI,
+        CompilationOutput.DEVDOC,
+        CompilationOutput.USERDOC
+    ];
+
     if (fileName === "--") {
         const content = fse.readFileSync(0, { encoding: "utf-8" });
 
@@ -152,9 +160,17 @@ function compile(
                   JSON.parse(content),
                   compilerVersion,
                   remapping,
+                  astOnlyOutput,
                   compilerSettings
               )
-            : compileSourceString(fileName, content, compilerVersion, remapping, compilerSettings);
+            : compileSourceString(
+                  fileName,
+                  content,
+                  compilerVersion,
+                  remapping,
+                  astOnlyOutput,
+                  compilerSettings
+              );
     }
 
     if (!fileName || !fse.existsSync(fileName)) {
@@ -168,8 +184,8 @@ function compile(
     }
 
     return type === "json"
-        ? compileJson(fileName, compilerVersion, remapping, compilerSettings)
-        : compileSol(fileName, compilerVersion, remapping, compilerSettings);
+        ? compileJson(fileName, compilerVersion, remapping, astOnlyOutput, compilerSettings)
+        : compileSol(fileName, compilerVersion, remapping, astOnlyOutput, compilerSettings);
 }
 
 /**
@@ -800,6 +816,7 @@ if ("version" in options) {
                         flatContents,
                         version,
                         pathRemapping,
+                        [CompilationOutput.ALL],
                         compilerSettings
                     );
                 } catch (e) {


### PR DESCRIPTION
This PR changes scribble behavior to NOT require successful ir/bytecode generation when instrumenting in flat or files mode. This is done by only requiring ast,abi and userdoc output from the underlying solidity compiler. Note that successful bytecode generation is still required when instrumenting in json mode.