### PR TITLE
Fix for #75

### DIFF
--- a/src/instrumenter/transpile.ts
+++ b/src/instrumenter/transpile.ts
@@ -69,6 +69,7 @@ import { TranspilingContext } from "./transpiling_context";
 
 /**
  * Transpile the `TypeNode` `type` (using the passed in `ASTNodeFactory`).
+ * @todo (dimo,pavel): Remove this and replace all uses with ScribbleFactory.typeNodeToVariableDecl.
  */
 export function transpileType(type: TypeNode, factory: ASTNodeFactory): TypeName {
     if (

--- a/src/rewriter/flatten.ts
+++ b/src/rewriter/flatten.ts
@@ -2,7 +2,6 @@ import {
     SourceUnit,
     ExportedSymbol,
     ImportDirective,
-    ASTNode,
     ContractDefinition,
     FunctionDefinition,
     ASTNodeFactory,
@@ -18,7 +17,7 @@ import {
     assert,
     PragmaDirective
 } from "solc-typed-ast";
-import { getOrInit, topoSort } from "../util";
+import { getFQName, getOrInit, topoSort } from "../util";
 
 /**
  * When flattening units, we may introduce two definitions with the same name.
@@ -59,41 +58,6 @@ function fixNameConflicts(units: SourceUnit[]): Set<ExportedSymbol> {
     }
 
     return renamed;
-}
-
-function getTypeScope(n: ASTNode): SourceUnit | ContractDefinition {
-    const typeScope = n.getClosestParentBySelector(
-        (p: ASTNode) => p instanceof SourceUnit || p instanceof ContractDefinition
-    ) as SourceUnit | ContractDefinition;
-    return typeScope;
-}
-
-function getFQName(def: ExportedSymbol, atUseSite: ASTNode): string {
-    if (def instanceof ImportDirective) {
-        return def.unitAlias;
-    }
-
-    if (def instanceof ContractDefinition) {
-        return def.name;
-    }
-
-    const scope = def.vScope;
-    assert(
-        scope instanceof SourceUnit || scope instanceof ContractDefinition,
-        `Unexpected scope ${
-            scope.constructor.name
-        } for def ${def.print()} at site ${atUseSite.print()}}`
-    );
-
-    if (scope instanceof SourceUnit) {
-        return def.name;
-    }
-
-    if (def instanceof FunctionDefinition && getTypeScope(def) === getTypeScope(atUseSite)) {
-        return def.name;
-    }
-
-    return scope.name + "." + def.name;
 }
 
 /**

--- a/test/samples/calldata_paramteres.instrumented.sol
+++ b/test/samples/calldata_paramteres.instrumented.sol
@@ -35,7 +35,7 @@ contract Test is __scribble_ReentrancyUtils {
 
     function _original_Test_moo() private {
         bytes memory m = "abc";
-        bytes memory n = _callsite_27(this.foo, m);
+        bytes memory n = _callsite_27(this, m);
         assert(n[0] == "a");
         assert(n[1] == "b");
         assert(n[2] == "c");
@@ -60,10 +60,10 @@ contract Test is __scribble_ReentrancyUtils {
         __scribble_out_of_contract = true;
     }
 
-    function _callsite_27(function(bytes memory) external returns (bytes memory) fPtr, bytes memory arg0) private returns (bytes memory ret0) {
+    function _callsite_27(Test receiver, bytes memory arg0) private returns (bytes memory ret0) {
         __scribble_check_state_invariants();
         __scribble_out_of_contract = true;
-        (ret0) = fPtr(arg0);
+        (ret0) = receiver.foo(arg0);
         __scribble_out_of_contract = false;
     }
 }

--- a/test/samples/contract_decorated_ext_call.instrumented.sol
+++ b/test/samples/contract_decorated_ext_call.instrumented.sol
@@ -38,13 +38,13 @@ contract Foo is __scribble_ReentrancyUtils {
 
     function fail_int() internal {
         x = 0;
-        _callsite_23(this.inc, 0);
+        _callsite_23(this, 0);
         x = 0;
-        _callsite_34(this.inc, 10000);
+        _callsite_34(this, 10000);
         x = 0;
-        _callsite_45(this.inc, 0, 10000);
+        _callsite_45(this, 0, 10000);
         x = 0;
-        _callsite_59(this.inc, 0, 10000);
+        _callsite_59(this, 0, 10000);
     }
 
     function fail() public {
@@ -93,31 +93,31 @@ contract Foo is __scribble_ReentrancyUtils {
         __scribble_out_of_contract = true;
     }
 
-    function _callsite_23(function() external payable fPtr, uint256 _value) private {
+    function _callsite_23(Foo receiver, uint256 _value) private {
         __scribble_check_state_invariants();
         __scribble_out_of_contract = true;
-        fPtr{value: _value}();
+        receiver.inc{value: _value}();
         __scribble_out_of_contract = false;
     }
 
-    function _callsite_34(function() external payable fPtr, uint256 _gas) private {
+    function _callsite_34(Foo receiver, uint256 _gas) private {
         __scribble_check_state_invariants();
         __scribble_out_of_contract = true;
-        fPtr{gas: _gas}();
+        receiver.inc{gas: _gas}();
         __scribble_out_of_contract = false;
     }
 
-    function _callsite_45(function() external payable fPtr, uint256 _value, uint256 _gas) private {
+    function _callsite_45(Foo receiver, uint256 _value, uint256 _gas) private {
         __scribble_check_state_invariants();
         __scribble_out_of_contract = true;
-        fPtr{gas: _gas, value: _value}();
+        receiver.inc{gas: _gas, value: _value}();
         __scribble_out_of_contract = false;
     }
 
-    function _callsite_59(function() external payable fPtr, uint256 _value, uint256 _gas) private {
+    function _callsite_59(Foo receiver, uint256 _value, uint256 _gas) private {
         __scribble_check_state_invariants();
         __scribble_out_of_contract = true;
-        fPtr{gas: _gas, value: _value}();
+        receiver.inc{gas: _gas, value: _value}();
         __scribble_out_of_contract = false;
     }
 

--- a/test/samples/contract_decorated_ext_callv05.instrumented.sol
+++ b/test/samples/contract_decorated_ext_callv05.instrumented.sol
@@ -38,11 +38,11 @@ contract Foo is __scribble_ReentrancyUtils {
 
     function fail_int() internal {
         x = 0;
-        _callsite_23(this.inc, 0);
+        _callsite_23(this, 0);
         x = 0;
-        _callsite_34(this.inc, 10000);
+        _callsite_34(this, 10000);
         x = 0;
-        _callsite_45(this.inc, 0, 10000);
+        _callsite_45(this, 0, 10000);
     }
 
     function fail() public {
@@ -91,24 +91,24 @@ contract Foo is __scribble_ReentrancyUtils {
         __scribble_out_of_contract = true;
     }
 
-    function _callsite_23(function() external payable fPtr, uint256 _value) private {
+    function _callsite_23(Foo receiver, uint256 _value) private {
         __scribble_check_state_invariants();
         __scribble_out_of_contract = true;
-        fPtr.value(_value)();
+        receiver.inc.value(_value)();
         __scribble_out_of_contract = false;
     }
 
-    function _callsite_34(function() external payable fPtr, uint256 _gas) private {
+    function _callsite_34(Foo receiver, uint256 _gas) private {
         __scribble_check_state_invariants();
         __scribble_out_of_contract = true;
-        fPtr.gas(_gas)();
+        receiver.inc.gas(_gas)();
         __scribble_out_of_contract = false;
     }
 
-    function _callsite_45(function() external payable fPtr, uint256 _value, uint256 _gas) private {
+    function _callsite_45(Foo receiver, uint256 _value, uint256 _gas) private {
         __scribble_check_state_invariants();
         __scribble_out_of_contract = true;
-        fPtr.gas(_gas).value(_value)();
+        receiver.inc.gas(_gas).value(_value)();
         __scribble_out_of_contract = false;
     }
 

--- a/test/samples/contract_pos_ext_call_fail.instrumented.sol
+++ b/test/samples/contract_pos_ext_call_fail.instrumented.sol
@@ -34,7 +34,7 @@ contract Foo is __scribble_ReentrancyUtils {
 
     function fail_int() internal {
         x = 0;
-        _callsite_23(this.inc);
+        _callsite_23(this);
     }
 
     function fail() public {
@@ -69,10 +69,10 @@ contract Foo is __scribble_ReentrancyUtils {
         __scribble_out_of_contract = true;
     }
 
-    function _callsite_23(function() external fPtr) private {
+    function _callsite_23(Foo receiver) private {
         __scribble_check_state_invariants();
         __scribble_out_of_contract = true;
-        fPtr();
+        receiver.inc();
         __scribble_out_of_contract = false;
     }
 }

--- a/test/unit/interposing.spec.ts
+++ b/test/unit/interposing.spec.ts
@@ -371,7 +371,7 @@ contract Foo is __scribble_ReentrancyUtils {
     }
 
     function mainView(uint y) public view returns (uint) {
-        return _callsite_30(this.viewF) + this.pureF(y);
+        return _callsite_30(this) + this.pureF(y);
     }
 
     /// Check only the current contract's state invariants
@@ -388,9 +388,9 @@ contract Foo is __scribble_ReentrancyUtils {
         __scribble_out_of_contract = true;
     }
 
-    function _callsite_30(function() external view returns (uint) fPtr) private view returns (uint ret0) {
+    function _callsite_30(Foo receiver) private view returns (uint256 ret0) {
         __scribble_check_state_invariants();
-        (ret0) = fPtr();
+        (ret0) = receiver.viewF();
     }
 }`
         ]
@@ -449,11 +449,11 @@ contract Foo {
     function foo() public {}
 
     function main() public {
-        _callsite_11(this.foo);
+        _callsite_11(this);
     }
 
-    function _callsite_11(function() external fPtr) private {
-        fPtr();
+    function _callsite_11(Foo receiver) private {
+        receiver.foo();
     }
 }`
         ],
@@ -475,11 +475,11 @@ contract Foo {
     function foo() public returns (uint) {}
 
     function main() public returns (uint) {
-        return _callsite_14(this.foo);
+        return _callsite_14(this);
     }
 
-    function _callsite_14(function() external returns (uint) fPtr) private returns (uint ret0) {
-        (ret0) = fPtr();
+    function _callsite_14(Foo receiver) private returns (uint256 ret0) {
+        (ret0) = receiver.foo();
     }
 }`
         ],
@@ -504,11 +504,11 @@ contract Foo {
     }
 
     function main() public returns (int) {
-        return _callsite_21(this.inc, 1) + 1;
+        return _callsite_21(this, 1) + 1;
     }
 
-    function _callsite_21(function(int) external returns (int) fPtr, int arg0) private returns (int ret0) {
-        (ret0) = fPtr(arg0);
+    function _callsite_21(Foo receiver, int256 arg0) private returns (int256 ret0) {
+        (ret0) = receiver.inc(arg0);
     }
 }`
         ],
@@ -534,12 +534,12 @@ contract Foo {
     }
 
     function main() public returns (int) {
-        (int a, int b) = _callsite_31(this.dup, 4);
+        (int a, int b) = _callsite_31(this, 4);
         return a + b;
     }
 
-    function _callsite_31(function(int) external returns (int, int) fPtr, int arg0) private returns (int ret0, int ret1) {
-        (ret0, ret1) = fPtr(arg0);
+    function _callsite_31(Foo receiver, int256 arg0) private returns (int256 ret0, int256 ret1) {
+        (ret0, ret1) = receiver.dup(arg0);
     }
 }`
         ],
@@ -598,11 +598,11 @@ contract Foo {
     }
 
     function main() public {
-        _callsite_20(this.pureF, 1);
+        _callsite_20(this, 1);
     }
 
-    function _callsite_20(function(uint) external pure returns (uint) fPtr, uint arg0) private pure returns (uint ret0) {
-        (ret0) = fPtr(arg0);
+    function _callsite_20(Foo receiver, uint256 arg0) private pure returns (uint256 ret0) {
+        (ret0) = receiver.pureF(arg0);
     }
 }`
         ]


### PR DESCRIPTION
This PR fixes #75.

Specifically it:

1. Changes the behavior of `interposeCall` to  obtain the original function arguments/returns from the callee type rather than the original definition. This avoids issues with public state var implementation for args/returns getters missing from solc-typed-ast

2. Change external call interposing to pass the receiver instead of a function pointer. This is an unrelated fix that will make our instrumentation more friendly to SMT verificaiton tools such as SMTChecker and solc-verify, that don't handle function pointers well yet.