### PR TITLE
[WIP] Add proper annotation metadata

### DIFF
--- a/src/bin/scribble.ts
+++ b/src/bin/scribble.ts
@@ -303,7 +303,13 @@ function instrumentFiles(
                     fun.stateMutability !== FunctionStateMutability.Pure &&
                     fun.stateMutability !== FunctionStateMutability.View
                 ) {
-                    annotations = annotations.concat(allowedFuncProp);
+                    if (fun.isConstructor) {
+                        annotations = annotations.concat(
+                            allowedFuncProp.filter((annot) => !annot.parsedAnnot.skipConstructor)
+                        );
+                    } else {
+                        annotations = annotations.concat(allowedFuncProp);
+                    }
                 }
 
                 /**

--- a/src/bin/scribble.ts
+++ b/src/bin/scribble.ts
@@ -303,13 +303,7 @@ function instrumentFiles(
                     fun.stateMutability !== FunctionStateMutability.Pure &&
                     fun.stateMutability !== FunctionStateMutability.View
                 ) {
-                    if (fun.isConstructor) {
-                        annotations = annotations.concat(
-                            allowedFuncProp.filter((annot) => !annot.parsedAnnot.skipConstructor)
-                        );
-                    } else {
-                        annotations = annotations.concat(allowedFuncProp);
-                    }
+                    annotations = annotations.concat(allowedFuncProp);
                 }
 
                 /**

--- a/src/spec-lang/ast/declarations/annotation.ts
+++ b/src/spec-lang/ast/declarations/annotation.ts
@@ -14,9 +14,10 @@ export enum AnnotationType {
 }
 
 export type AnnotationMDExpr = SNumber | SBooleanLiteral | SStringLiteral;
+export type AnnotationMDExprConstructor<T extends AnnotationMDExpr> = new (...args: any[]) => T;
 export type AnnotationMD = { [key: string]: AnnotationMDExpr };
 
-const knownMDTypes = new Map<string, any>([["msg", SStringLiteral]]);
+const knownMDTypes = new Map<string, AnnotationMDExprConstructor<any>>([["msg", SStringLiteral]]);
 
 export abstract class SAnnotation extends SNode {
     public readonly type: AnnotationType;
@@ -40,7 +41,9 @@ export abstract class SAnnotation extends SNode {
 
             if (!(val instanceof expectedType)) {
                 throw new Error(
-                    `Expected key ${key} to be a ${expectedType}, not ${val} of type ${typeof val}`
+                    `Expected key ${key} to be a ${
+                        expectedType.constructor.name
+                    }, not ${val} of type ${typeof val}`
                 );
             }
 

--- a/src/spec-lang/ast/declarations/annotation.ts
+++ b/src/spec-lang/ast/declarations/annotation.ts
@@ -16,16 +16,12 @@ export enum AnnotationType {
 export type AnnotationMDExpr = SNumber | SBooleanLiteral | SStringLiteral;
 export type AnnotationMD = { [key: string]: AnnotationMDExpr };
 
-const knownMDTypes = new Map<string, any>([
-    ["msg", SStringLiteral],
-    ["skipConstructor", SBooleanLiteral]
-]);
+const knownMDTypes = new Map<string, any>([["msg", SStringLiteral]]);
 
 export abstract class SAnnotation extends SNode {
     public readonly type: AnnotationType;
     public readonly md: AnnotationMD;
     public readonly label?: string;
-    public readonly skipConstructor: boolean = false;
 
     prefix: string | undefined;
 
@@ -50,10 +46,8 @@ export abstract class SAnnotation extends SNode {
 
             if (key === "msg") {
                 this.label = (val as SStringLiteral).val;
-            }
-
-            if (key === "skipConstructor") {
-                this.skipConstructor = (val as SBooleanLiteral).val;
+            } else {
+                throw new Error(`NYI metadata key ${key}`);
             }
         }
     }

--- a/src/spec-lang/ast/declarations/if_assigned.ts
+++ b/src/spec-lang/ast/declarations/if_assigned.ts
@@ -1,5 +1,6 @@
 import { AnnotationType } from ".";
 import { SNode, Range } from "..";
+import { AnnotationMD } from "./annotation";
 import { DatastructurePath, SStateVarProp } from "./state_var_prop";
 
 /**
@@ -11,7 +12,7 @@ import { DatastructurePath, SStateVarProp } from "./state_var_prop";
  *
  */
 export class SIfAssigned extends SStateVarProp {
-    constructor(expression: SNode, path: DatastructurePath, label?: string, src?: Range) {
-        super(AnnotationType.IfAssigned, expression, path, label, src);
+    constructor(expression: SNode, path: DatastructurePath, md?: AnnotationMD, src?: Range) {
+        super(AnnotationType.IfAssigned, expression, path, md, src);
     }
 }

--- a/src/spec-lang/ast/declarations/if_updated.ts
+++ b/src/spec-lang/ast/declarations/if_updated.ts
@@ -1,6 +1,7 @@
 import { AnnotationType } from ".";
 import { SNode, Range } from "..";
 import { assert } from "../../../util/misc";
+import { AnnotationMD } from "./annotation";
 import { DatastructurePath, SStateVarProp } from "./state_var_prop";
 
 /**
@@ -17,8 +18,8 @@ import { DatastructurePath, SStateVarProp } from "./state_var_prop";
  *
  */
 export class SIfUpdated extends SStateVarProp {
-    constructor(expression: SNode, path: DatastructurePath, label?: string, src?: Range) {
+    constructor(expression: SNode, path: DatastructurePath, md?: AnnotationMD, src?: Range) {
         assert(path.length === 0, `Not yet support if_updated with a path`);
-        super(AnnotationType.IfUpdated, expression, path, label, src);
+        super(AnnotationType.IfUpdated, expression, path, md, src);
     }
 }

--- a/src/spec-lang/ast/declarations/property.ts
+++ b/src/spec-lang/ast/declarations/property.ts
@@ -1,10 +1,10 @@
 import { Range, SNode } from "../node";
-import { AnnotationType, SAnnotation } from "./annotation";
+import { AnnotationMD, AnnotationType, SAnnotation } from "./annotation";
 
 export class SProperty extends SAnnotation {
     public readonly expression: SNode;
-    constructor(type: AnnotationType, expression: SNode, label?: string, src?: Range) {
-        super(type, label, src);
+    constructor(type: AnnotationType, expression: SNode, md?: AnnotationMD, src?: Range) {
+        super(type, md, src);
         this.expression = expression;
     }
 

--- a/src/spec-lang/ast/declarations/state_var_prop.ts
+++ b/src/spec-lang/ast/declarations/state_var_prop.ts
@@ -1,6 +1,7 @@
 import { AnnotationType } from ".";
 import { SNode, Range } from "..";
 import { SId } from "../identifier";
+import { AnnotationMD } from "./annotation";
 import { SProperty } from "./property";
 
 /**
@@ -19,10 +20,10 @@ export class SStateVarProp extends SProperty {
         annotationType: AnnotationType,
         expression: SNode,
         path: DatastructurePath,
-        label?: string,
+        md?: AnnotationMD,
         src?: Range
     ) {
-        super(annotationType, expression, label, src);
+        super(annotationType, expression, md, src);
         this.datastructurePath = path;
     }
 

--- a/src/spec-lang/ast/declarations/user_function_definition.ts
+++ b/src/spec-lang/ast/declarations/user_function_definition.ts
@@ -1,7 +1,7 @@
 import { TypeNode } from "solc-typed-ast";
 import { SId } from "../identifier";
 import { Range, SNode } from "../node";
-import { AnnotationType, SAnnotation } from "./annotation";
+import { AnnotationMD, AnnotationType, SAnnotation } from "./annotation";
 
 export class SUserFunctionDefinition extends SAnnotation {
     public readonly name: SId;
@@ -14,10 +14,10 @@ export class SUserFunctionDefinition extends SAnnotation {
         params: Array<[SId, TypeNode]>,
         returnType: TypeNode,
         body: SNode,
-        label?: string,
+        md?: AnnotationMD,
         src?: Range
     ) {
-        super(AnnotationType.Define, label, src);
+        super(AnnotationType.Define, md, src);
         this.name = name;
         this.parameters = params;
         this.returnType = returnType;

--- a/src/spec-lang/expr_grammar.pegjs
+++ b/src/spec-lang/expr_grammar.pegjs
@@ -63,7 +63,7 @@ MDExpressionList =
 
 
 AnnotationMD =
-    "{" __  exprs: MDExpressionList __ "}" { return exprs; }
+    "{" __  exprs: MDExpressionList? __ "}" { return exprs === null ? undefined : exprs; }
 
 Invariant =
     type: INVARIANT __ md: AnnotationMD? __ expr: Expression __ ";" {
@@ -143,21 +143,21 @@ IndexPath =
 // TODO: Eventually remove hacky '/' from if_updated rule. This is to work around
 // limitations in Solidity - it throws if it sees natspec on internal state vars
 If_Updated =
-    ("/" __)? type: IF_UPDATED __ label: AnnotationMD? __ expr: Expression __ ";" {
+    ("/" __)? type: IF_UPDATED __ md: AnnotationMD? __ expr: Expression __ ";" {
         return new SIfUpdated(
             expr,
             [],
-            label === null ? undefined : label,
+            md === null ? undefined : md,
             location()
         );
     }
 
 If_Assigned =
-    ("/" __)? type: IF_ASSIGNED path: IndexPath __ label: AnnotationMD? __ expr: Expression __ ";" {
+    ("/" __)? type: IF_ASSIGNED path: IndexPath __ md: AnnotationMD? __ expr: Expression __ ";" {
         return new SIfAssigned(
             expr,
             path,
-            label === null ? undefined : label,
+            md === null ? undefined : md,
             location()
         );
     }
@@ -184,13 +184,13 @@ TypedArgs =
     }
 
 UserFunctionDefinition =
-    type: DEFINE __ label: AnnotationMD? __ name: Identifier __ "(" __ args: TypedArgs? __ ")" __ returnType: Type __ "=" __ body: Expression {
+    type: DEFINE __ md: AnnotationMD? __ name: Identifier __ "(" __ args: TypedArgs? __ ")" __ returnType: Type __ "=" __ body: Expression {
         return new SUserFunctionDefinition(
             name,
             args === null ? [] : args,
             returnType,
             body,
-            label === null ? undefined : label,
+            md === null ? undefined : md,
             location()
         );
     }

--- a/src/spec-lang/expr_grammar.pegjs
+++ b/src/spec-lang/expr_grammar.pegjs
@@ -29,15 +29,48 @@ AnnotationStr =
     "'" chars: SingleStringChar* "'" { return chars.join(""); }
     / '"' chars: DoubleStringChar* '"' { return chars.join(""); }
 
-AnnotationLabel =
-    "{:msg" __  str: AnnotationStr __ "}" { return str; }
+MDExpression =
+    HexLiteral
+    / Identifier
+    / Number
+    / BooleanLiteral
+    / StringLiteral
+
+MDIdentifier = chars:([a-zA-Z_][a-zA-Z0-9_]*) { return text(); }
+
+MDExpressionList =
+    head: (
+        ":" key: MDIdentifier __ expr: MDExpression {
+            return [key, expr]
+        }
+    )
+    tail: (
+        __ "," __ ":" key: MDIdentifier __ expr: MDExpression {
+            return [key, expr];
+        }
+    )* {
+        const base = {};
+        base[head[0]] = head[1];
+
+        return tail.reduce(
+            (acc, el) => {
+                acc[el[0]] = el[1]
+                return acc;
+            },
+            base
+        );
+    }
+
+
+AnnotationMD =
+    "{" __  exprs: MDExpressionList __ "}" { return exprs; }
 
 Invariant =
-    type: INVARIANT __ label: AnnotationLabel? __ expr: Expression __ ";" {
+    type: INVARIANT __ md: AnnotationMD? __ expr: Expression __ ";" {
         return new SProperty(
             type as AnnotationType,
             expr,
-            label === null ? undefined : label,
+            md === null ? undefined : md,
             location()
         );
     }
@@ -59,41 +92,41 @@ For_All =
     }
 
 If_Succeeds =
-    type: IF_SUCCEEDS __ label: AnnotationLabel? __ expr: Expression __ ";" {
+    type: IF_SUCCEEDS __ md: AnnotationMD? __ expr: Expression __ ";" {
         return new SProperty(
             type as AnnotationType,
             expr,
-            label === null ? undefined : label,
+            md === null ? undefined : md,
             location()
         );
     }
 
 Assert =
-    type: ASSERT __ label: AnnotationLabel? __ expr: Expression __ ";" {
+    type: ASSERT __ md: AnnotationMD? __ expr: Expression __ ";" {
         return new SProperty (
             type as AnnotationType,
             expr,
-            label === null ? undefined : label,
+            md === null ? undefined : md,
             location()
         );
     }
 
 Try =
-    type: TRY __ label: AnnotationLabel? __ expr: Expression __ ";" {
+    type: TRY __ md: AnnotationMD? __ expr: Expression __ ";" {
         return new SProperty (
             type as AnnotationType,
             expr,
-            label === null ? undefined : label,
+            md === null ? undefined : md,
             location()
         );
     }
 
 Require =
-    type: REQUIRE __ label: AnnotationLabel? __ expr: Expression __ ";" {
+    type: REQUIRE __ md: AnnotationMD? __ expr: Expression __ ";" {
         return new SProperty (
             type as AnnotationType,
             expr,
-            label === null ? undefined : label,
+            md === null ? undefined : md,
             location()
         );
     }
@@ -110,7 +143,7 @@ IndexPath =
 // TODO: Eventually remove hacky '/' from if_updated rule. This is to work around
 // limitations in Solidity - it throws if it sees natspec on internal state vars
 If_Updated =
-    ("/" __)? type: IF_UPDATED __ label: AnnotationLabel? __ expr: Expression __ ";" {
+    ("/" __)? type: IF_UPDATED __ label: AnnotationMD? __ expr: Expression __ ";" {
         return new SIfUpdated(
             expr,
             [],
@@ -120,7 +153,7 @@ If_Updated =
     }
 
 If_Assigned =
-    ("/" __)? type: IF_ASSIGNED path: IndexPath __ label: AnnotationLabel? __ expr: Expression __ ";" {
+    ("/" __)? type: IF_ASSIGNED path: IndexPath __ label: AnnotationMD? __ expr: Expression __ ";" {
         return new SIfAssigned(
             expr,
             path,
@@ -151,7 +184,7 @@ TypedArgs =
     }
 
 UserFunctionDefinition =
-    type: DEFINE __ label: AnnotationLabel? __ name: Identifier __ "(" __ args: TypedArgs? __ ")" __ returnType: Type __ "=" __ body: Expression {
+    type: DEFINE __ label: AnnotationMD? __ name: Identifier __ "(" __ args: TypedArgs? __ ")" __ returnType: Type __ "=" __ body: Expression {
         return new SUserFunctionDefinition(
             name,
             args === null ? [] : args,

--- a/test/unit/parser.spec.ts
+++ b/test/unit/parser.spec.ts
@@ -20,6 +20,7 @@ import {
     SNumber,
     SProperty,
     SResult,
+    SStringLiteral,
     SUnaryOperation,
     SUserFunctionDefinition
 } from "../../src/spec-lang/ast";
@@ -639,7 +640,9 @@ describe("Annotation Parser Unit Tests", () => {
 
         [
             '/// if_succeeds {:msg "hi"} true;',
-            new SProperty(AnnotationType.IfSucceeds, new SBooleanLiteral(true), "hi")
+            new SProperty(AnnotationType.IfSucceeds, new SBooleanLiteral(true), {
+                msg: new SStringLiteral("hi")
+            })
         ],
         [
             `* if_succeeds 
@@ -652,7 +655,7 @@ describe("Annotation Parser Unit Tests", () => {
             new SProperty(
                 AnnotationType.IfSucceeds,
                 new SBinaryOperation(new SNumber(bigInt(1), 10), "-", new SNumber(bigInt(2), 10)),
-                "hi"
+                { msg: new SStringLiteral("hi") }
             )
         ],
         [
@@ -666,7 +669,7 @@ describe("Annotation Parser Unit Tests", () => {
             new SIfUpdated(
                 new SBinaryOperation(new SNumber(bigInt(1), 10), "-", new SNumber(bigInt(2), 10)),
                 [],
-                "hi"
+                { msg: new SStringLiteral("hi") }
             )
         ],
         [
@@ -676,7 +679,9 @@ describe("Annotation Parser Unit Tests", () => {
                     }
                     true;
                      ;`,
-            new SIfAssigned(new SBooleanLiteral(true), [new SId("a")], "bye")
+            new SIfAssigned(new SBooleanLiteral(true), [new SId("a")], {
+                msg: new SStringLiteral("bye")
+            })
         ],
         [
             `* if_assigned.foo
@@ -685,7 +690,7 @@ describe("Annotation Parser Unit Tests", () => {
                     }
                     true;
                      ;`,
-            new SIfAssigned(new SBooleanLiteral(true), ["foo"], "bye")
+            new SIfAssigned(new SBooleanLiteral(true), ["foo"], { msg: new SStringLiteral("bye") })
         ],
         [
             `* if_assigned._bar0.boo[a][b].foo[c]
@@ -697,7 +702,7 @@ describe("Annotation Parser Unit Tests", () => {
             new SIfAssigned(
                 new SBooleanLiteral(false),
                 ["_bar0", "boo", new SId("a"), new SId("b"), "foo", new SId("c")],
-                "felicia"
+                { msg: new SStringLiteral("felicia") }
             )
         ],
         [
@@ -711,7 +716,7 @@ describe("Annotation Parser Unit Tests", () => {
             new SProperty(
                 AnnotationType.Invariant,
                 new SBinaryOperation(new SNumber(bigInt(1), 10), "-", new SNumber(bigInt(2), 10)),
-                "hi"
+                { msg: new SStringLiteral("hi") }
             )
         ],
         [
@@ -748,7 +753,7 @@ describe("Annotation Parser Unit Tests", () => {
                 [],
                 new BoolType(),
                 new SBooleanLiteral(true),
-                "tralala"
+                { msg: new SStringLiteral("tralala") }
             )
         ],
         [
@@ -768,7 +773,7 @@ describe("Annotation Parser Unit Tests", () => {
                 [],
                 new BoolType(),
                 new SBooleanLiteral(true),
-                "tralala"
+                { msg: new SStringLiteral("tralala") }
             )
         ],
         [
@@ -829,6 +834,12 @@ describe("Annotation Parser Unit Tests", () => {
         ],
         ["/// assert true;", new SProperty(AnnotationType.Assert, new SBooleanLiteral(true))],
         [
+            "/// assert {:skipConstructor true} true;",
+            new SProperty(AnnotationType.Assert, new SBooleanLiteral(true), {
+                skipConstructor: new SBooleanLiteral(true)
+            })
+        ],
+        [
             "/// assert forall (uint x in a) a[x] > 10;",
             new SProperty(
                 AnnotationType.Assert,
@@ -884,7 +895,9 @@ describe("Annotation Parser Unit Tests", () => {
                        "bye"
                     }
                     true;
-                     ;`
+                     ;`,
+        `/// if_succeeds {bad: "true"} true;`,
+        `/// if_succeeds {msg: 1} true;`
     ];
 
     for (const [sample, expected] of goodSamples) {

--- a/test/unit/parser.spec.ts
+++ b/test/unit/parser.spec.ts
@@ -834,12 +834,6 @@ describe("Annotation Parser Unit Tests", () => {
         ],
         ["/// assert true;", new SProperty(AnnotationType.Assert, new SBooleanLiteral(true))],
         [
-            "/// assert {:skipConstructor true} true;",
-            new SProperty(AnnotationType.Assert, new SBooleanLiteral(true), {
-                skipConstructor: new SBooleanLiteral(true)
-            })
-        ],
-        [
             "/// assert forall (uint x in a) a[x] > 10;",
             new SProperty(
                 AnnotationType.Assert,

--- a/test/unit/parser.spec.ts
+++ b/test/unit/parser.spec.ts
@@ -833,6 +833,7 @@ describe("Annotation Parser Unit Tests", () => {
             )
         ],
         ["/// assert true;", new SProperty(AnnotationType.Assert, new SBooleanLiteral(true))],
+        ["/// assert {} true;", new SProperty(AnnotationType.Assert, new SBooleanLiteral(true))],
         [
             "/// assert forall (uint x in a) a[x] > 10;",
             new SProperty(


### PR DESCRIPTION
NOTE: This PR depends on #112 . After that merges this should be re-targeted to develop.

This PR doesn't have many visible changes. It tweaks the grammar and the datatypes inside `SAnnotation` to allow adding more metadata tags other than just `:msg`. Closes #115 