### PR TITLE
Fixes for bugs #121 and #123

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ src/spec-lang/typeString_parser.ts
 src/rewriter/import_directive_parser.ts
 .vscode/launch.json
 test/multifile_samples/*/__scribble_ReentrancyUtils.sol
+test/multifile_samples/*/*.sol.instrumented

--- a/src/spec-lang/expr_grammar.pegjs
+++ b/src/spec-lang/expr_grammar.pegjs
@@ -19,9 +19,7 @@ Annotation =
         return annotation;
     }
 
-Expression =
-    For_All
-    / LetExpression
+Expression = LetExpression
 
 // Non-top-level rules
 
@@ -445,6 +443,7 @@ PrimaryExpression =
         "(" __ expr: Expression __ ")" { return expr; }
     )
     / (RESULT { return new SResult(location()); })
+    / For_All
 
 OldExpression =
     OLD __ "(" __ expr: Expression __ ")" {

--- a/src/spec-lang/tc/builtins.ts
+++ b/src/spec-lang/tc/builtins.ts
@@ -9,12 +9,63 @@ import {
     FunctionVisibility,
     IntType,
     PointerType,
+    StringType,
     TypeNode
 } from "solc-typed-ast";
-import { BuiltinStructType } from "./internal_types";
+import { BuiltinStructType, VariableTypes } from "./internal_types";
 
 export const BuiltinSymbols = new Map<string, TypeNode | [TypeNode, string]>([
-    ["abi", new BuiltinStructType("abi", new Map())],
+    [
+        "abi",
+        new BuiltinStructType(
+            "abi",
+            new Map<string, TypeNode>([
+                [
+                    "encode",
+                    new FunctionType(
+                        "encode",
+                        [new VariableTypes()],
+                        [new PointerType(new BytesType(), DataLocation.Memory)],
+                        FunctionVisibility.Default,
+                        FunctionStateMutability.Pure
+                    )
+                ],
+                [
+                    "encodePacked",
+                    new FunctionType(
+                        "encodePacked",
+                        [new VariableTypes()],
+                        [new PointerType(new BytesType(), DataLocation.Memory)],
+                        FunctionVisibility.Default,
+                        FunctionStateMutability.Pure
+                    )
+                ],
+                [
+                    "encodeWithSelector",
+                    new FunctionType(
+                        "encodeWithSelector",
+                        [new FixedBytesType(4), new VariableTypes()],
+                        [new PointerType(new BytesType(), DataLocation.Memory)],
+                        FunctionVisibility.Default,
+                        FunctionStateMutability.Pure
+                    )
+                ],
+                [
+                    "encodeWithSignature",
+                    new FunctionType(
+                        "encodeWithSignature",
+                        [
+                            new PointerType(new StringType(), DataLocation.Memory),
+                            new VariableTypes()
+                        ],
+                        [new PointerType(new BytesType(), DataLocation.Memory)],
+                        FunctionVisibility.Default,
+                        FunctionStateMutability.Pure
+                    )
+                ]
+            ])
+        )
+    ],
     [
         "block",
         new BuiltinStructType(

--- a/src/spec-lang/tc/internal_types/index.ts
+++ b/src/spec-lang/tc/internal_types/index.ts
@@ -1,3 +1,4 @@
 export * from "./builtin_struct_type";
 export * from "./function_set_type";
 export * from "./import_ref_type";
+export * from "./variable_types";

--- a/src/spec-lang/tc/internal_types/variable_types.ts
+++ b/src/spec-lang/tc/internal_types/variable_types.ts
@@ -1,0 +1,15 @@
+import { TypeNode } from "solc-typed-ast/dist/types/ast/type";
+
+/**
+ * Place-holder type that can match any number of types. Used in the
+ * args of variadic builtin functions: abi.encode*
+ */
+export class VariableTypes extends TypeNode {
+    getFields(): any {
+        return [];
+    }
+
+    pp(): string {
+        return "<any types>";
+    }
+}

--- a/src/spec-lang/tc/typecheck.ts
+++ b/src/spec-lang/tc/typecheck.ts
@@ -1409,7 +1409,10 @@ export function tcMemberAccess(expr: SMemberAccess, ctx: STypingCtx, typeEnv: Ty
         const baseLoc = baseT.location;
         const baseToT = baseT.to;
 
-        if (baseToT instanceof ArrayType && expr.member === "length") {
+        if (
+            (baseToT instanceof ArrayType || baseToT instanceof BytesType) &&
+            expr.member === "length"
+        ) {
             return new IntType(256, false);
         }
 

--- a/src/spec-lang/tc/typecheck.ts
+++ b/src/spec-lang/tc/typecheck.ts
@@ -1668,7 +1668,7 @@ function matchArguments(
         if (formalT instanceof VariableTypes) {
             assert(
                 i === funT.parameters.length - 1,
-                `Unexpected variable type not in last position of fun {1}`,
+                `Unexpected variable type not in last position of fun {0}`,
                 funT
             );
             return true;

--- a/test/samples/encode.instrumented.sol
+++ b/test/samples/encode.instrumented.sol
@@ -1,0 +1,58 @@
+pragma solidity 0.8.7;
+
+contract Foo {
+    event AssertionFailed(string message);
+
+    function foo(uint v) public {
+        _original_Foo_foo(v);
+        unchecked {
+            if (!(abi.encode(v).length > 0)) {
+                emit AssertionFailed("0: ");
+                assert(false);
+            }
+        }
+    }
+
+    function _original_Foo_foo(uint v) private {}
+
+    function foo1(uint v) public {
+        _original_Foo_foo1(v);
+        unchecked {
+            if (!(abi.encodePacked(v).length > 0)) {
+                emit AssertionFailed("1: ");
+                assert(false);
+            }
+        }
+    }
+
+    function _original_Foo_foo1(uint v) private {}
+
+    function foo2(uint v) public {
+        _original_Foo_foo2(v);
+        unchecked {
+            if (!(abi.encodeWithSelector(bytes4(hex"01020304"), v).length > 0)) {
+                emit AssertionFailed("2: ");
+                assert(false);
+            }
+        }
+    }
+
+    function _original_Foo_foo2(uint v) private {}
+
+    function foo3(uint v) public {
+        _original_Foo_foo3(v);
+        unchecked {
+            if (!(abi.encodeWithSignature("dummy", v).length > 0)) {
+                emit AssertionFailed("3: ");
+                assert(false);
+            }
+        }
+    }
+
+    function _original_Foo_foo3(uint v) private {}
+}
+
+/// Utility contract holding a stack counter
+contract __scribble_ReentrancyUtils {
+    bool __scribble_out_of_contract = true;
+}

--- a/test/samples/encode.sol
+++ b/test/samples/encode.sol
@@ -1,0 +1,17 @@
+contract Foo {
+ /// #if_succeeds abi.encode(v).length > 0;
+ function foo(uint v) public {
+ }
+
+ /// #if_succeeds abi.encodePacked(v).length > 0;
+ function foo1(uint v) public {
+ }
+
+ /// #if_succeeds abi.encodeWithSelector(bytes4(hex"01020304"), v).length > 0;
+ function foo2(uint v) public {
+ }
+
+ /// #if_succeeds abi.encodeWithSignature("dummy", v).length > 0;
+ function foo3(uint v) public {
+ }
+}

--- a/test/unit/parser.spec.ts
+++ b/test/unit/parser.spec.ts
@@ -590,7 +590,49 @@ describe("Expression Parser Unit Tests", () => {
                 new SNumber(BigInt(10), 10)
             )
         ],
-        ["$result", new SResult()]
+        ["$result", new SResult()],
+        [
+            "true && forall (uint x in 1...10) a[x]>10",
+            new SBinaryOperation(
+                new SBooleanLiteral(true),
+                "&&",
+                new SForAll(
+                    new IntType(256, false),
+                    new SId("x"),
+                    new SBinaryOperation(
+                        new SIndexAccess(new SId("a"), new SId("x")),
+                        ">",
+                        new SNumber(BigInt(10), 10)
+                    ),
+                    new SNumber(BigInt(1), 10),
+                    new SNumber(BigInt(10), 10)
+                )
+            )
+        ],
+        [
+            "true && forall (uint x in 1...10) true || forall (uint x in 1...10) false",
+            new SBinaryOperation(
+                new SBooleanLiteral(true),
+                "&&",
+                new SForAll(
+                    new IntType(256, false),
+                    new SId("x"),
+                    new SBinaryOperation(
+                        new SBooleanLiteral(true),
+                        "||",
+                        new SForAll(
+                            new IntType(256, false),
+                            new SId("x"),
+                            new SBooleanLiteral(false),
+                            new SNumber(BigInt(1), 10),
+                            new SNumber(BigInt(10), 10)
+                        )
+                    ),
+                    new SNumber(BigInt(1), 10),
+                    new SNumber(BigInt(10), 10)
+                )
+            )
+        ]
     ];
 
     const badSamples: string[] = [

--- a/test/unit/tc.spec.ts
+++ b/test/unit/tc.spec.ts
@@ -519,7 +519,49 @@ describe("TypeChecker Expression Unit Tests", () => {
                     new TupleType([new IntType(256, false), new IntType(256, false)])
                 ],
                 ["unchecked_sum(sM)", ["Foo"], new IntType(256, true)],
-                ["unchecked_sum(sI64Arr)", ["Foo"], new IntType(256, true)]
+                ["unchecked_sum(sI64Arr)", ["Foo"], new IntType(256, true)],
+                ["abi.encode()", ["Foo"], new PointerType(new BytesType(), DataLocation.Memory)],
+                ["abi.encode(sV)", ["Foo"], new PointerType(new BytesType(), DataLocation.Memory)],
+                [
+                    "abi.encode(sM, sI64Arr, gasleft())",
+                    ["Foo"],
+                    new PointerType(new BytesType(), DataLocation.Memory)
+                ],
+                [
+                    "abi.encodePacked()",
+                    ["Foo"],
+                    new PointerType(new BytesType(), DataLocation.Memory)
+                ],
+                [
+                    "abi.encodePacked(sV)",
+                    ["Foo"],
+                    new PointerType(new BytesType(), DataLocation.Memory)
+                ],
+                [
+                    "abi.encode(sM, sI64Arr, gasleft())",
+                    ["Foo"],
+                    new PointerType(new BytesType(), DataLocation.Memory)
+                ],
+                [
+                    "abi.encodeWithSelector(bytes4(0x01020304))",
+                    ["Foo"],
+                    new PointerType(new BytesType(), DataLocation.Memory)
+                ],
+                [
+                    "abi.encodeWithSelector(bytes4(0x01020304), sV, sV1)",
+                    ["Foo"],
+                    new PointerType(new BytesType(), DataLocation.Memory)
+                ],
+                [
+                    'abi.encodeWithSignature("foo")',
+                    ["Foo"],
+                    new PointerType(new BytesType(), DataLocation.Memory)
+                ],
+                [
+                    'abi.encodeWithSignature("foo", sV, sV1)',
+                    ["Foo"],
+                    new PointerType(new BytesType(), DataLocation.Memory)
+                ]
             ]
         ],
         [
@@ -645,7 +687,11 @@ describe("TypeChecker Expression Unit Tests", () => {
                 ["$result", ["Foo", "noReturn"]],
                 ["forall (string x in 0...100) x > 0", ["Foo"]],
                 ["forall (uint x in sV) x > 0", ["Foo"]],
-                ["unchecked_sum(sV)", ["Foo"]]
+                ["unchecked_sum(sV)", ["Foo"]],
+                ["abi.encodeWithSelector()", ["Foo"]],
+                ["abi.encodeWithSelector(sV)", ["Foo"]],
+                ["abi.encodeWithSignature()", ["Foo"]],
+                ["abi.encodeWithSignature(sV)", ["Foo"]]
             ]
         ],
         [


### PR DESCRIPTION
This PR fixes #121  and #123 . Specifically:

1. Fix for #121  - tweak the grammar to support `forall`s inside boolean expressions without parenthesis. Add parsing tests
2. Fix for #123  - support the `abi.encode*` family of builtins. To do this adds a new internal `VariableTypes` type node, used to denote variable number of arguments for functions; Add typing definitions for the `abi.encode*` functions in `src/spec-lang/tc/builtins.ts`; Tweak `typecheck.ts` to handle type-checking of functions with variable number of arguments.

Note: We still don't support `abi.decode` as that additionally requires adding tuples to the scribble language.