### PR TITLE
Support annotation label short-hand with just a string

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -351,9 +351,9 @@
             "integrity": "sha512-rIY/6WPm7T8n3qS2vuHTUBPdXHl+rGxWxW5okDfo9J4Z0+gRRZT0msvUdIJkE4/HS29GUMziwGaaKO2bWONBrg=="
         },
         "@ethersproject/networks": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.5.0.tgz",
-            "integrity": "sha512-KWfP3xOnJeF89Uf/FCJdV1a2aDJe5XTN2N52p4fcQ34QhDqQFkgQKZ39VGtiqUgHcLI8DfT0l9azC3KFTunqtA==",
+            "version": "5.5.2",
+            "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.5.2.tgz",
+            "integrity": "sha512-NEqPxbGBfy6O3x4ZTISb90SjEDkWYDUbEeIFhJly0F7sZjoQMnj5KYzMSkMkLKZ+1fGpx00EDpHQCy6PrDupkQ==",
             "requires": {
                 "@ethersproject/logger": "^5.5.0"
             }
@@ -415,9 +415,9 @@
             }
         },
         "@ethersproject/web": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.5.0.tgz",
-            "integrity": "sha512-BEgY0eL5oH4mAo37TNYVrFeHsIXLRxggCRG/ksRIxI2X5uj5IsjGmcNiRN/VirQOlBxcUhCgHhaDLG4m6XAVoA==",
+            "version": "5.5.1",
+            "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.5.1.tgz",
+            "integrity": "sha512-olvLvc1CB12sREc1ROPSHTdFCdvMh0J5GSJYiQg2D0hdD4QmJDy8QYDb1CvoqD/bF1c++aeKv2sR5uduuG9dQg==",
             "requires": {
                 "@ethersproject/base64": "^5.5.0",
                 "@ethersproject/bytes": "^5.5.0",
@@ -2729,6 +2729,7 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
             "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+            "dev": true,
             "requires": {
                 "is-extglob": "^2.1.1"
             }
@@ -5119,12 +5120,51 @@
                 }
             }
         },
-        "solc-typed-ast": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/solc-typed-ast/-/solc-typed-ast-7.0.2.tgz",
-            "integrity": "sha512-XNBki4nNt65eU8K1BbBtLnzW+gTmlbxabwGfRTN77zASI099jvdxIRiKWTcUqKmPvbJuZES7L2aCNxMKbdRstQ==",
+        "solc-0.4.13": {
+            "version": "npm:solc@0.4.13",
+            "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.13.tgz",
+            "integrity": "sha1-qly9zOPmrjwZDSD1/fi8iAcC7HU=",
             "requires": {
-                "findup-sync": "^4.0.0",
+                "fs-extra": "^0.30.0",
+                "memorystream": "^0.3.1",
+                "require-from-string": "^1.1.0",
+                "semver": "^5.3.0",
+                "yargs": "^4.7.1"
+            },
+            "dependencies": {
+                "fs-extra": {
+                    "version": "0.30.0",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+                    "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "jsonfile": "^2.1.0",
+                        "klaw": "^1.0.0",
+                        "path-is-absolute": "^1.0.0",
+                        "rimraf": "^2.2.8"
+                    }
+                },
+                "jsonfile": {
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+                    "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+                    "requires": {
+                        "graceful-fs": "^4.1.6"
+                    }
+                },
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+                }
+            }
+        },
+        "solc-typed-ast": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/solc-typed-ast/-/solc-typed-ast-7.2.0.tgz",
+            "integrity": "sha512-Y/bjpUE6vv8X2do55QkJFOvv5qBAEmkqtdTfamNU0RJrTeXePhAf1fD4CymBMDQLkUo5cDcjf5Yxi1w3cQDx5A==",
+            "requires": {
+                "findup-sync": "^5.0.0",
                 "fs-extra": "^10.0.0",
                 "jsel": "^1.1.6",
                 "minimist": "^1.2.5",
@@ -5183,14 +5223,17 @@
                 "solc-0.7.6": "npm:solc@0.7.6",
                 "solc-0.8.0": "npm:solc@0.8.0",
                 "solc-0.8.1": "npm:solc-0.8.1-fixed@0.8.1",
+                "solc-0.8.10": "npm:solc@0.8.10",
                 "solc-0.8.2": "npm:solc@0.8.2",
                 "solc-0.8.3": "npm:solc@0.8.3",
                 "solc-0.8.4": "npm:solc@0.8.4",
                 "solc-0.8.5": "npm:solc@0.8.5",
                 "solc-0.8.6": "npm:solc@0.8.6",
                 "solc-0.8.7": "npm:solc@0.8.7-fixed",
+                "solc-0.8.8": "npm:solc@0.8.8",
+                "solc-0.8.9": "npm:solc@0.8.9",
                 "src-location": "^1.1.0",
-                "web3-eth-abi": "^1.5.2"
+                "web3-eth-abi": "^1.6.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -5219,17 +5262,6 @@
                     "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
                     "requires": {
                         "locate-path": "^2.0.0"
-                    }
-                },
-                "findup-sync": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-4.0.0.tgz",
-                    "integrity": "sha512-6jvvn/12IC4quLBL1KNokxC7wWTvYncaVUYSoxWw7YykPLuRrnv4qdHcSOywOI5RpkOVGeQRtWM8/q+G6W6qfQ==",
-                    "requires": {
-                        "detect-file": "^1.0.0",
-                        "is-glob": "^4.0.0",
-                        "micromatch": "^4.0.2",
-                        "resolve-dir": "^1.0.1"
                     }
                 },
                 "invert-kv": {
@@ -5293,37 +5325,6 @@
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
                     "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
-                },
-                "solc-0.4.13": {
-                    "version": "npm:solc@0.4.13",
-                    "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.13.tgz",
-                    "integrity": "sha1-qly9zOPmrjwZDSD1/fi8iAcC7HU=",
-                    "requires": {
-                        "fs-extra": "^0.30.0",
-                        "memorystream": "^0.3.1",
-                        "require-from-string": "^1.1.0",
-                        "semver": "^5.3.0",
-                        "yargs": "^4.7.1"
-                    },
-                    "dependencies": {
-                        "fs-extra": {
-                            "version": "0.30.0",
-                            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
-                            "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
-                            "requires": {
-                                "graceful-fs": "^4.1.2",
-                                "jsonfile": "^2.1.0",
-                                "klaw": "^1.0.0",
-                                "path-is-absolute": "^1.0.0",
-                                "rimraf": "^2.2.8"
-                            }
-                        },
-                        "semver": {
-                            "version": "5.7.1",
-                            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                        }
-                    }
                 },
                 "solc-0.4.14": {
                     "version": "npm:solc@0.4.14",
@@ -7716,6 +7717,51 @@
                         }
                     }
                 },
+                "solc-0.8.10": {
+                    "version": "npm:solc@0.8.10",
+                    "resolved": "https://registry.npmjs.org/solc/-/solc-0.8.10.tgz",
+                    "integrity": "sha512-I/Mcn6J5bEtJqveNLplQm9IRrhemm6v+qkw5S2+wM4x9HItJ1sYdrqVTN3j4DMhFDM3ZbvM0QywVzpPx666PHw==",
+                    "requires": {
+                        "command-exists": "^1.2.8",
+                        "commander": "^8.1.0",
+                        "follow-redirects": "^1.12.1",
+                        "fs-extra": "^0.30.0",
+                        "js-sha3": "0.8.0",
+                        "memorystream": "^0.3.1",
+                        "require-from-string": "^2.0.0",
+                        "semver": "^5.5.0",
+                        "tmp": "0.0.33"
+                    },
+                    "dependencies": {
+                        "commander": {
+                            "version": "8.3.0",
+                            "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+                            "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="
+                        },
+                        "fs-extra": {
+                            "version": "0.30.0",
+                            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+                            "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
+                            "requires": {
+                                "graceful-fs": "^4.1.2",
+                                "jsonfile": "^2.1.0",
+                                "klaw": "^1.0.0",
+                                "path-is-absolute": "^1.0.0",
+                                "rimraf": "^2.2.8"
+                            }
+                        },
+                        "require-from-string": {
+                            "version": "2.0.2",
+                            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+                            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+                        },
+                        "semver": {
+                            "version": "5.7.1",
+                            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+                        }
+                    }
+                },
                 "solc-0.8.2": {
                     "version": "npm:solc@0.8.2",
                     "resolved": "https://registry.npmjs.org/solc/-/solc-0.8.2.tgz",
@@ -7932,6 +7978,96 @@
                         "tmp": "0.0.33"
                     },
                     "dependencies": {
+                        "fs-extra": {
+                            "version": "0.30.0",
+                            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+                            "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
+                            "requires": {
+                                "graceful-fs": "^4.1.2",
+                                "jsonfile": "^2.1.0",
+                                "klaw": "^1.0.0",
+                                "path-is-absolute": "^1.0.0",
+                                "rimraf": "^2.2.8"
+                            }
+                        },
+                        "require-from-string": {
+                            "version": "2.0.2",
+                            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+                            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+                        },
+                        "semver": {
+                            "version": "5.7.1",
+                            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+                        }
+                    }
+                },
+                "solc-0.8.8": {
+                    "version": "npm:solc@0.8.8",
+                    "resolved": "https://registry.npmjs.org/solc/-/solc-0.8.8.tgz",
+                    "integrity": "sha512-u5N7fq4kABwyLKDbt9Xq99OiYBP7x56Pl/Oyz4TbNr9xbjgaMW2lhNIAZWtTme7Iuufw+3Tq5Ts3Bia56BOkvQ==",
+                    "requires": {
+                        "command-exists": "^1.2.8",
+                        "commander": "^8.1.0",
+                        "follow-redirects": "^1.12.1",
+                        "fs-extra": "^0.30.0",
+                        "js-sha3": "0.8.0",
+                        "memorystream": "^0.3.1",
+                        "require-from-string": "^2.0.0",
+                        "semver": "^5.5.0",
+                        "tmp": "0.0.33"
+                    },
+                    "dependencies": {
+                        "commander": {
+                            "version": "8.3.0",
+                            "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+                            "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="
+                        },
+                        "fs-extra": {
+                            "version": "0.30.0",
+                            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+                            "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
+                            "requires": {
+                                "graceful-fs": "^4.1.2",
+                                "jsonfile": "^2.1.0",
+                                "klaw": "^1.0.0",
+                                "path-is-absolute": "^1.0.0",
+                                "rimraf": "^2.2.8"
+                            }
+                        },
+                        "require-from-string": {
+                            "version": "2.0.2",
+                            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+                            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+                        },
+                        "semver": {
+                            "version": "5.7.1",
+                            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+                        }
+                    }
+                },
+                "solc-0.8.9": {
+                    "version": "npm:solc@0.8.9",
+                    "resolved": "https://registry.npmjs.org/solc/-/solc-0.8.9.tgz",
+                    "integrity": "sha512-dD8tQgGCrdWQPpbDTbQF048S3JAcpytOax2r5qPgQluKJPCRFT6c/fec0ZkbrRwRSeYT/qiKz0OKBDOinnGeWw==",
+                    "requires": {
+                        "command-exists": "^1.2.8",
+                        "commander": "^8.1.0",
+                        "follow-redirects": "^1.12.1",
+                        "fs-extra": "^0.30.0",
+                        "js-sha3": "0.8.0",
+                        "memorystream": "^0.3.1",
+                        "require-from-string": "^2.0.0",
+                        "semver": "^5.5.0",
+                        "tmp": "0.0.33"
+                    },
+                    "dependencies": {
+                        "commander": {
+                            "version": "8.3.0",
+                            "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+                            "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="
+                        },
                         "fs-extra": {
                             "version": "0.30.0",
                             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -8607,18 +8743,18 @@
             }
         },
         "web3-eth-abi": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.6.0.tgz",
-            "integrity": "sha512-fImomGE9McuTMJLwK8Tp0lTUzXqCkWeMm00qPVIwpJ/h7lCw9UFYV9+4m29wSqW6FF+FIZKwc6UBEf9dlx3orA==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.7.0.tgz",
+            "integrity": "sha512-heqR0bWxgCJwjWIhq2sGyNj9bwun5+Xox/LdZKe+WMyTSy0cXDXEAgv3XKNkXC4JqdDt/ZlbTEx4TWak4TRMSg==",
             "requires": {
                 "@ethersproject/abi": "5.0.7",
-                "web3-utils": "1.6.0"
+                "web3-utils": "1.7.0"
             }
         },
         "web3-utils": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.6.0.tgz",
-            "integrity": "sha512-bgCAWAeQnJF035YTFxrcHJ5mGEfTi/McsjqldZiXRwlHK7L1PyOqvXiQLE053dlzvy1kdAxWl/sSSfLMyNUAXg==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.0.tgz",
+            "integrity": "sha512-O8Tl4Ky40Sp6pe89Olk2FsaUkgHyb5QAXuaKo38ms3CxZZ4d3rPGfjP9DNKGm5+IUgAZBNpF1VmlSmNCqfDI1w==",
             "requires": {
                 "bn.js": "^4.11.9",
                 "ethereum-bloom-filters": "^1.0.6",

--- a/src/spec-lang/expr_grammar.pegjs
+++ b/src/spec-lang/expr_grammar.pegjs
@@ -59,8 +59,9 @@ MDExpressionList =
     }
 
 
-AnnotationMD =
-    "{" __  exprs: MDExpressionList? __ "}" { return exprs === null ? undefined : exprs; }
+AnnotationMD
+    = "{" __  exprs: MDExpressionList? __ "}" { return exprs === null ? undefined : exprs; }
+    / msg: StringLiteral { return { msg } }
 
 Invariant =
     type: INVARIANT __ md: AnnotationMD? __ expr: Expression __ ";" {

--- a/test/unit/parser.spec.ts
+++ b/test/unit/parser.spec.ts
@@ -909,7 +909,27 @@ describe("Annotation Parser Unit Tests", () => {
                     new SId("a")
                 )
             )
-        ]
+        ],
+        [
+            '/// #if_succeeds "test" forall (uint x in a) a[x]>10;',
+            new SProperty(
+                AnnotationType.IfSucceeds,
+                new SForAll(
+                    new IntType(256, false),
+                    new SId("x"),
+                    new SBinaryOperation(
+                        new SIndexAccess(new SId("a"), new SId("x")),
+                        ">",
+                        new SNumber(BigInt(10), 10)
+                    ),
+                    undefined,
+                    undefined,
+                    new SId("a")
+                ),
+                { msg: new SStringLiteral("test") }
+            )
+        ],
+        ["/// #assert true;", new SProperty(AnnotationType.Assert, new SBooleanLiteral(true))]
     ];
 
     const badSamples: string[] = [


### PR DESCRIPTION
This adds a small shorthand for annotation labels. Instead of having to write this:

```
#invariant {:msg "Invariant1"} ...;
```

Now you can just write:

```
#invariant "Invariant1" ...;
```

The old syntax is still supported.