### PR TITLE
Disallow arrays and maps in old()

### DIFF
--- a/src/spec-lang/tc/semcheck.ts
+++ b/src/spec-lang/tc/semcheck.ts
@@ -1,4 +1,5 @@
 import {
+    ArrayType,
     assert,
     FunctionStateMutability,
     FunctionType,
@@ -305,6 +306,17 @@ export function scUnary(
     const annotType = ctx.annotation.type;
 
     if (expr.op === "old") {
+        const exprT = typeEnv.typeOf(expr);
+
+        if (exprT instanceof PointerType) {
+            if (exprT.to instanceof ArrayType) {
+                throw new SemError(`old() expressions over arrays are not allowed`, expr);
+            }
+
+            if (exprT.to instanceof MappingType) {
+                throw new SemError(`old() expressions over maps are not allowed`, expr);
+            }
+        }
         if (
             !(
                 ctx.annotation.type === AnnotationType.IfSucceeds ||

--- a/src/spec-lang/tc/semcheck.ts
+++ b/src/spec-lang/tc/semcheck.ts
@@ -1,11 +1,13 @@
 import {
     ArrayType,
     assert,
+    BytesType,
     FunctionStateMutability,
     FunctionType,
     MappingType,
     PointerType,
     SourceUnit,
+    StringType,
     TypeNameType,
     VariableDeclaration
 } from "solc-typed-ast";
@@ -308,15 +310,19 @@ export function scUnary(
     if (expr.op === "old") {
         const exprT = typeEnv.typeOf(expr);
 
-        if (exprT instanceof PointerType) {
-            if (exprT.to instanceof ArrayType) {
-                throw new SemError(`old() expressions over arrays are not allowed`, expr);
-            }
-
-            if (exprT.to instanceof MappingType) {
-                throw new SemError(`old() expressions over maps are not allowed`, expr);
-            }
+        if (
+            exprT instanceof PointerType &&
+            (exprT.to instanceof ArrayType ||
+                exprT.to instanceof MappingType ||
+                exprT.to instanceof StringType ||
+                exprT.to instanceof BytesType)
+        ) {
+            throw new SemError(
+                `old() expressions over dynamically sized types (e.g. arrays, maps, strings, bytes) are not allowed`,
+                expr
+            );
         }
+
         if (
             !(
                 ctx.annotation.type === AnnotationType.IfSucceeds ||

--- a/test/samples/forall_maps.instrumented.sol
+++ b/test/samples/forall_maps.instrumented.sol
@@ -683,14 +683,14 @@ contract Foo is __scribble_ReentrancyUtils {
             _v.forall_13 = true;
             for (_v.i14 = 1; _v.i14 < k.keys.length; _v.i14++) {
                 _v.i13 = k.keys[_v.i14];
-                _v.old_0 = uint256_to_uint256.get(k, _v.i13) > 0;
-                _v.forall_13 = _v.old_0;
+                _v.forall_13 = uint256_to_uint256.get(k, _v.i13) > 0;
                 if (!_v.forall_13) break;
             }
+            _v.old_0 = _v.forall_13;
         }
         _original_Foo_setK1(i, v);
         unchecked {
-            if (!(_v.forall_13)) {
+            if (!(_v.old_0)) {
                 emit AssertionFailed("11: ");
                 assert(false);
             }

--- a/test/samples/forall_maps.sol
+++ b/test/samples/forall_maps.sol
@@ -108,7 +108,7 @@ contract Foo {
         k[i] = v;
     }
 
-    /// #if_succeeds forall(uint i in old(k)) old(k[i] > 0);
+    /// #if_succeeds old(forall(uint i in k) k[i] > 0);
     function setK1(uint i, uint v) public {
         k[i] = v;
     }

--- a/test/unit/sc.spec.ts
+++ b/test/unit/sc.spec.ts
@@ -291,7 +291,7 @@ describe("SemanticChecker Expression Unit Tests", () => {
                     { isOld: false, isConst: false, canFail: false }
                 ],
                 [
-                    "unchecked_sum(old(m1))",
+                    "old(unchecked_sum(m1))",
                     ["Foo", "add"],
                     new IntType(256, false),
                     { isOld: true, isConst: false, canFail: false }
@@ -315,7 +315,7 @@ describe("SemanticChecker Expression Unit Tests", () => {
                     { isOld: true, isConst: false, canFail: true }
                 ],
                 [
-                    "forall (string memory s in old(m1)) old(m1[s] > 0)",
+                    "old(forall (string memory s in m1) m1[s] > 0)",
                     ["Foo", "add"],
                     new BoolType(),
                     { isOld: true, isConst: false, canFail: true }


### PR DESCRIPTION
This PR disallows old expressions of the type `old(e)` where e is of type array or map. Note that `old(e[x])`is still allowed as long as its a primitive type. Fixes #150  and #152 