### PR TITLE
Fix for #163

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
                 "glob": "^7.2.0",
                 "logplease": "^1.2.15",
                 "semver": "^7.3.5",
-                "solc-typed-ast": "^9.1.1",
+                "solc-typed-ast": "^9.1.2",
                 "src-location": "^1.1.0",
                 "yaml": "^1.10.2"
             },
@@ -6137,9 +6137,9 @@
             }
         },
         "node_modules/solc-typed-ast": {
-            "version": "9.1.1",
-            "resolved": "https://registry.npmjs.org/solc-typed-ast/-/solc-typed-ast-9.1.1.tgz",
-            "integrity": "sha512-O+PqTPX6Vtn2ScR7EbOjBuida2BDtqDQXSPk8eHhOnMKHRPxPmTqQO4XSHY06THTVfQhCQOf0IhzzHMnTBdRww==",
+            "version": "9.1.2",
+            "resolved": "https://registry.npmjs.org/solc-typed-ast/-/solc-typed-ast-9.1.2.tgz",
+            "integrity": "sha512-OV+ctwq4LMDCwdyZAMl4XsxeXlR/ctQa+EAcyosKI5CzuyRpNeEGFhaB7tV1F4IgU3KdYXcJdeC82gkZR6EW7g==",
             "dependencies": {
                 "axios": "^0.26.1",
                 "findup-sync": "^5.0.0",
@@ -11337,9 +11337,9 @@
             }
         },
         "solc-typed-ast": {
-            "version": "9.1.1",
-            "resolved": "https://registry.npmjs.org/solc-typed-ast/-/solc-typed-ast-9.1.1.tgz",
-            "integrity": "sha512-O+PqTPX6Vtn2ScR7EbOjBuida2BDtqDQXSPk8eHhOnMKHRPxPmTqQO4XSHY06THTVfQhCQOf0IhzzHMnTBdRww==",
+            "version": "9.1.2",
+            "resolved": "https://registry.npmjs.org/solc-typed-ast/-/solc-typed-ast-9.1.2.tgz",
+            "integrity": "sha512-OV+ctwq4LMDCwdyZAMl4XsxeXlR/ctQa+EAcyosKI5CzuyRpNeEGFhaB7tV1F4IgU3KdYXcJdeC82gkZR6EW7g==",
             "requires": {
                 "axios": "^0.26.1",
                 "findup-sync": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "fs-extra": "^10.0.1",
         "logplease": "^1.2.15",
         "semver": "^7.3.5",
-        "solc-typed-ast": "^9.1.1",
+        "solc-typed-ast": "^9.1.2",
         "src-location": "^1.1.0",
         "findup-sync": "^5.0.0",
         "yaml": "^1.10.2",

--- a/src/bin/scribble.ts
+++ b/src/bin/scribble.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import fse from "fs-extra";
 import { dirname, join, relative, resolve } from "path";
+import { normalize } from "path/posix";
 import {
     assert,
     ASTContext,
@@ -491,8 +492,8 @@ function pickUtilsLocAndImport(
         }
 
         const pkgPath = dirname(pkgPaths[0]);
-
-        return [pkgPath, pkgPath.replace(remappedPrefix, prefix)];
+        const normalizedPrefix = normalize(remappedPrefix);
+        return [pkgPath, pkgPath.replace(normalizedPrefix, prefix)];
     }
 
     // If no remapping to a node-module was found, then place the utils unit alongside the

--- a/test/unit/tc.spec.ts
+++ b/test/unit/tc.spec.ts
@@ -728,6 +728,37 @@ contract UserDefinedValueTypes {
                 ["uint(1).foo()", ["Foo"], new IntType(256, false)],
                 ["int(1).boo()", ["Foo"], new IntType(256, true)]
             ]
+        ],
+        [
+            "private_state_var.sol",
+            `pragma solidity 0.8.13;
+        contract Base {
+            uint private x;
+        }
+        
+        contract Child is Base {
+             /// #if_succeeds x == 42;
+             function foo() public {}
+        }
+        `,
+            [["x", ["Base"], new IntType(256, false)]]
+        ],
+        [
+            "private_state_var.sol",
+            `pragma solidity 0.8.13;
+        contract Base {
+            uint internal x;
+        }
+        
+        contract Child is Base {
+             /// #if_succeeds x == 42;
+             function foo() public {}
+        }
+        `,
+            [
+                ["x", ["Base"], new IntType(256, false)],
+                ["x", ["Child"], new IntType(256, false)]
+            ]
         ]
     ];
 
@@ -948,6 +979,34 @@ contract UserDefinedValueTypes {
                 ["int(1).foo()", ["Foo"]],
                 ["uint(1).boo()", ["Foo"]]
             ]
+        ],
+        [
+            "private_state_var.sol",
+            `pragma solidity 0.8.13;
+        contract Base {
+            uint private x;
+        }
+        
+        contract Child is Base {
+             /// #if_succeeds x == 42;
+             function foo() public {}
+        }`,
+            [["x", ["Child"]]]
+        ],
+        [
+            "private_fun.sol",
+            `pragma solidity 0.8.13;
+        contract Base {
+            function plusOne(uint x) private pure returns (uint) {
+                return x + 1;
+            }
+        }
+        
+        contract Child is Base {
+             /// #if_succeeds plusOne(x) == x + 1;
+             function foo(uint x) public {}
+        }`,
+            [["plusOne", ["Child"]]]
         ]
     ];
 


### PR DESCRIPTION
This PR includes:

* bump to solc-typed-ast version 9.1.2 which fixes #163  (for now - we may revisit this fix in the future under a different issue)
* small followup fix to the previous PR that fixed  https://github.com/ConsenSys/scribble/pull/161 - apparently when the remapping involved non-normalized elements such as './' or '//' that could confuse our logic for selecting where to place the utils unit