### PR TITLE
Allow structs to use bound library methods and fix imports in executable

### DIFF
--- a/src/bin/scribble.ts
+++ b/src/bin/scribble.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import fse from "fs-extra";
-import { dirname, join, relative, resolve } from "path";
-import { normalize } from "path/posix";
+import { dirname, join, relative, resolve, normalize } from "path";
 import {
     assert,
     ASTContext,

--- a/src/spec-lang/tc/typecheck.ts
+++ b/src/spec-lang/tc/typecheck.ts
@@ -1560,15 +1560,10 @@ export function tcMemberAccess(expr: SMemberAccess, ctx: STypingCtx, typeEnv: Ty
                     if (expr.member === rawDecl.name) {
                         // rawDecl.vType is defined, as you can't put a `var x;` in a struct definition.
                         expr.defSite = rawDecl;
+
                         return astVarToTypeNode(rawDecl, baseLoc);
                     }
                 }
-
-                throw new SNoField(
-                    `Struct ${baseToT.name} doesn't have a field ${expr.member}`,
-                    expr,
-                    expr.member
-                );
             }
         }
     }


### PR DESCRIPTION
## Tasks
- Fixes #174
- Fixes #175 

## Changes
- [x] Allowed struct expressions in annotations to use bound library methods (weakened the check, that was forcing to use only direct fields).
- [x] Fixed imports in Scribble executable.

Regards.