### PR TITLE
Properly support user-defined types with unqualified names

### DIFF
--- a/src/spec-lang/expr_parser_header.ts
+++ b/src/spec-lang/expr_parser_header.ts
@@ -92,7 +92,7 @@ function makeUserDefinedType(
 ): UserDefinedType {
     const version = options.version;
     const ctx = options.ctx;
-    const defs = [...resolveAny(name, ctx, version)];
+    const defs = [...resolveAny(name, ctx, version, true)];
 
     if (defs.length === 0) {
         throw new Error(`Couldn't find ${name}`);


### PR DESCRIPTION
## Tasks
This PR fixes #181

## Changes
- [x] Enabled inclusivity flag when resolving declarations while parsing `UserDefinedType`s to allow to use unqualified names.

## Notes
- PR are still missing some test samples.
- We still should better formulate an error message for `SNoField` when user passes `UserDefinedType` instead of `PointerType`.

Regards.