### PR TITLE
Automate package publishing via GitHub Actions workflow

### DIFF
--- a/.github/workflows/npm.yaml
+++ b/.github/workflows/npm.yaml
@@ -1,0 +1,19 @@
+name: Build and release package
+
+on:
+    release:
+        types: [published]
+
+jobs:
+    publish:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+            - uses: actions/setup-node@v3
+              with:
+                  node-version: 16
+                  registry-url: "https://registry.npmjs.org"
+            - run: npm install
+            - run: npm publish
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Changes
- Added `npm.yaml` GitHub Actions workflow file to automate package publishing. Package should publish when release tag is created. For additional info refer to [the sample](https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#publish-to-npmjs-and-gpr-with-npm).

## Notes
- The `NPM_TOKEN` **should be set in repository secrets** in order to allow automation to publish package to NPM registry.

Regards.