### PR TITLE
Tweak badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
   <img width="460" height="300" src="static/logo.png">
 </p>
 
-[![Build Status](https://drone.infra.mythx.io/api/badges/ConsenSys/scribble/status.svg)](https://drone.infra.mythx.io/ConsenSys/scribble)
+[![NodeJS CI](https://github.com/ConsenSys/scribble/actions/workflows/node.js.yaml/badge.svg)](https://github.com/ConsenSys/scribble/actions/workflows/node.js.yaml)
 [![Coverage](https://codecov.io/gh/ConsenSys/scribble/branch/develop/graph/badge.svg?token=yVZzF90k9k)](https://codecov.io/gh/ConsenSys/scribble)
 [![Documentation](https://aleen42.github.io/badges/src/gitbook_2.svg)](https://docs.scribble.codes)
 [![npm](https://img.shields.io/npm/v/eth-scribble)](https://www.npmjs.com/package/eth-scribble)
+[![npm downloads](https://img.shields.io/npm/dm/eth-scribble.svg)](https://www.npmjs.com/package/eth-scribble)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 A Solidity runtime verification tool for property based testing.


### PR DESCRIPTION
## Changes
- [x] Fixed CI badge to refer to GitHub Actions instead of Drone.
- [x] Added npm badge with monthly downloads.

You can check the results [here](https://github.com/Consensys/scribble/blob/a2e23cf74fa29318d0b15dcfb3aba3646c264260/README.md).

Regards.