### PR TITLE
Fix missing imports caused due to instrumentation

### DIFF
--- a/src/instrumenter/interpose.ts
+++ b/src/instrumenter/interpose.ts
@@ -431,6 +431,7 @@ export function interposeCall(
                 )
             );
 
+            ctx.needsDefinition(contract.vScope, baseT.definition);
             receiver = factory.copy(callee.vExpression);
             copySrc(callee.vExpression, receiver);
         } else {


### PR DESCRIPTION
Instrumentation (especially callsite interposing) may sometimes introduce variable declarations for types that are not in scope in a contract. Add functionality to accumulate new types that need to be imported at a particular source unit due to instrumentation and add those imports as needed