### PR TITLE
Dont interpose on callsites in view functions

### DIFF
--- a/src/instrumenter/instrument.ts
+++ b/src/instrumenter/instrument.ts
@@ -1054,9 +1054,18 @@ function replaceExternalCallSites(
             callSite
         );
 
+        // We skip instrumenting external calls in pure and view functions to
+        // avoid changing their mutability. This should not result in missing
+        // any invariant violations since the external call can only call
+        // another view/pure function, and as such can only return information
+        // to the current context without any other side effects. Thus even if
+        // there is a callback to this contract, that sees inconsistent state,
+        // its still functionally equivalent to an internal call chain since
+        // there are no other side-effects outside of this contract.
         if (
             calleeType instanceof FunctionType &&
-            calleeType.mutability === FunctionStateMutability.Pure
+            (calleeType.mutability === FunctionStateMutability.Pure ||
+                calleeType.mutability === FunctionStateMutability.View)
         ) {
             continue;
         }

--- a/test/unit/interposing.spec.ts
+++ b/test/unit/interposing.spec.ts
@@ -393,7 +393,7 @@ contract Foo {
     }
 
     function mainView(uint y) public view returns (uint) {
-        return _callsite_30(this) + this.pureF(y);
+        return this.viewF() + this.pureF(y);
     }
 
     /// Check only the current contract's state invariants
@@ -408,11 +408,6 @@ contract Foo {
         __ScribbleUtilsLib__40.setInContract(true);
         __scribble_check_state_invariants();
         __ScribbleUtilsLib__40.setInContract(false);
-    }
-
-    function _callsite_30(Foo receiver) private view returns (uint256 ret0) {
-        __scribble_check_state_invariants();
-        (ret0) = receiver.viewF();
     }
 }
 


### PR DESCRIPTION
We currently interpose on callsites inside view functions. The original reason for this is that we were worried about external view functions calling back into the contract and potentially getting inconsistent state. Specifically the scenario we were worried about was:

1. We are  in some non-view function F1 of contract C, that violates the invariant
2.  F1 calls F2 (internally), and F2 is a view function
3.  F2 calls (externally) F3 which is also view
4.  F3 calls back into C, and gets inconsistent state
5.  Inconsistent state gets propagated all the way back in to F1

However even if this happened, since the calls to F3 (and onwards) are all view, (and thus side-effect free), then the only thing that the inconsistent state of C can get propagate to is back to C itself. So logically this is similar to just doing internal calls to C (and potentially getting some extra consistent state from external contracts)

For this reason we decided not to instrument external callsites inside view functions, since these can sometimes break hardhat tests.