### PR TITLE
Bump solc-typed-ast to 18.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "fs-extra": "^11.2.0",
                 "logplease": "^1.2.15",
                 "semver": "^7.5.4",
-                "solc-typed-ast": "^18.0.0",
+                "solc-typed-ast": "^18.1.0",
                 "src-location": "^1.1.0",
                 "yaml": "^1.10.2"
             },
@@ -5282,9 +5282,9 @@
             }
         },
         "node_modules/solc-typed-ast": {
-            "version": "18.0.0",
-            "resolved": "https://registry.npmjs.org/solc-typed-ast/-/solc-typed-ast-18.0.0.tgz",
-            "integrity": "sha512-3atR71jFVJJgPZeep79I3ZD+OhZJv2/rwpTWVaF/pyUbFVNSz50wEDAZ1a9oXvcEkfLFfDxyp9oi6N1M+9Ns0Q==",
+            "version": "18.1.0",
+            "resolved": "https://registry.npmjs.org/solc-typed-ast/-/solc-typed-ast-18.1.0.tgz",
+            "integrity": "sha512-uD88IznJBgL0I7YHp4rA/g+Sy7wLSopmva060h/SdpJ0o8CgSduxyTgJtsJvFklUq2N7VnXZL9lju3oBqYB9tg==",
             "dependencies": {
                 "axios": "^1.6.5",
                 "commander": "^11.1.0",
@@ -10012,9 +10012,9 @@
             }
         },
         "solc-typed-ast": {
-            "version": "18.0.0",
-            "resolved": "https://registry.npmjs.org/solc-typed-ast/-/solc-typed-ast-18.0.0.tgz",
-            "integrity": "sha512-3atR71jFVJJgPZeep79I3ZD+OhZJv2/rwpTWVaF/pyUbFVNSz50wEDAZ1a9oXvcEkfLFfDxyp9oi6N1M+9Ns0Q==",
+            "version": "18.1.0",
+            "resolved": "https://registry.npmjs.org/solc-typed-ast/-/solc-typed-ast-18.1.0.tgz",
+            "integrity": "sha512-uD88IznJBgL0I7YHp4rA/g+Sy7wLSopmva060h/SdpJ0o8CgSduxyTgJtsJvFklUq2N7VnXZL9lju3oBqYB9tg==",
             "requires": {
                 "axios": "^1.6.5",
                 "commander": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "fs-extra": "^11.2.0",
         "logplease": "^1.2.15",
         "semver": "^7.5.4",
-        "solc-typed-ast": "^18.0.0",
+        "solc-typed-ast": "^18.1.0",
         "src-location": "^1.1.0",
         "yaml": "^1.10.2"
     },

--- a/src/ast_to_source_printer.ts
+++ b/src/ast_to_source_printer.ts
@@ -9,12 +9,12 @@ import {
     SrcRangeMap,
     SymbolAlias,
     assert,
-    toUTF8
+    bytesToString,
+    strUTF8Len
 } from "solc-typed-ast";
 import { ImportDirectiveDesc } from "./rewriter/import_directive_header";
 import { parse as parseImportDirective } from "./rewriter/import_directive_parser";
 import { SourceMap } from "./util/sources";
-import { strUTF8Len } from "./util";
 
 /**
  * Find an import named `name` imported from source unit `from`. This will
@@ -106,7 +106,7 @@ export function rewriteImports(
         assert(source !== undefined, `Missing source for ${sourceUnit.absolutePath}`);
 
         const importDirSrc = importDir.extractSourceFragment(source.rawContents);
-        const importDesc: ImportDirectiveDesc = parseImportDirective(toUTF8(importDirSrc));
+        const importDesc: ImportDirectiveDesc = parseImportDirective(bytesToString(importDirSrc));
 
         assert(
             importDesc.symbolAliases.length === importDir.symbolAliases.length,

--- a/src/bin/scribble.ts
+++ b/src/bin/scribble.ts
@@ -32,7 +32,7 @@ import {
     getCompilerPrefixForOs,
     isVisiblityExternallyCallable,
     parsePathRemapping,
-    toUTF8
+    bytesToString
 } from "solc-typed-ast";
 import { rewriteImports } from "../ast_to_source_printer";
 import {
@@ -110,7 +110,7 @@ function getSrcLine(l: Range | Location): string {
 
     lineEnd = lineEnd == -1 ? startLoc.file.rawContents.length : lineEnd;
 
-    return toUTF8(startLoc.file.rawContents.slice(lineStart, lineEnd));
+    return bytesToString(startLoc.file.rawContents.slice(lineStart, lineEnd));
 }
 
 /// TODO: Eventually make this support underlining a range spanning multiple liens

--- a/src/instrumenter/annotations.ts
+++ b/src/instrumenter/annotations.ts
@@ -10,9 +10,10 @@ import {
     Statement,
     StatementWithChildren,
     StructuredDocumentation,
-    toUTF8,
+    bytesToString,
     TryCatchClause,
-    VariableDeclaration
+    VariableDeclaration,
+    strUTF16IndexToUTF8Offset
 } from "solc-typed-ast";
 import { MacroDefinition, parseMacroMethodSignature } from "../macros";
 import {
@@ -29,14 +30,7 @@ import {
 } from "../spec-lang/ast";
 import { PeggySyntaxError as ExprPEGSSyntaxError, parseAnnotation } from "../spec-lang/expr_parser";
 import { PPAbleError } from "../util/errors";
-import {
-    adjustRange,
-    makeIdxToOffMap,
-    makeRange,
-    Range,
-    rangeToLocRange,
-    strUTF16IndexToUTF8Offset
-} from "../util";
+import { adjustRange, makeIdxToOffMap, makeRange, Range, rangeToLocRange } from "../util";
 import { getOr, getScopeUnit, zip } from "../util/misc";
 import { SourceFile, SourceMap } from "../util/sources";
 
@@ -410,7 +404,7 @@ function findAnnotations(
     const meta: RawMetaData = {
         target: target,
         node: raw,
-        text: toUTF8(raw.extractSourceFragment(source.rawContents)),
+        text: bytesToString(raw.extractSourceFragment(source.rawContents)),
         docFileOffset: sourceInfo.offset
     };
 

--- a/src/instrumenter/deprecated_warnings.ts
+++ b/src/instrumenter/deprecated_warnings.ts
@@ -8,7 +8,7 @@ import {
     Statement,
     StatementWithChildren,
     StructuredDocumentation,
-    toUTF8,
+    bytesToString,
     VariableDeclaration
 } from "solc-typed-ast";
 import { SAnnotation } from "../spec-lang/ast/declarations/annotation";
@@ -35,7 +35,7 @@ function findAnnotationsInStr(
     fixer: (match: RegExpExecArray, text: string) => string
 ): Array<Range | Location> {
     const res: Array<Range | Location> = [];
-    const text = toUTF8(doc.extractSourceFragment(file.rawContents));
+    const text = bytesToString(doc.extractSourceFragment(file.rawContents));
 
     let match = rx.exec(text);
 

--- a/src/instrumenter/instrumentation_context.ts
+++ b/src/instrumenter/instrumentation_context.ts
@@ -7,7 +7,7 @@ import {
     EnumDefinition,
     EventDefinition,
     Expression,
-    fromUTF8,
+    stringToBytes,
     FunctionCallKind,
     FunctionDefinition,
     ImportDirective,
@@ -21,7 +21,7 @@ import {
     SrcRangeMap,
     Statement,
     StructDefinition,
-    toUTF8,
+    bytesToString,
     TypeNode,
     VariableDeclaration
 } from "solc-typed-ast";
@@ -504,7 +504,7 @@ export class InstrumentationContext {
         srcMap: SrcRangeMap
     ): string {
         const replaceMarker = "000000:0000:000";
-        const byteContents = fromUTF8(contents);
+        const byteContents = stringToBytes(contents);
 
         for (const [lit, targetNode] of this.litAdjustMap) {
             if (lit.getClosestParentByType(SourceUnit) !== unit) {
@@ -520,7 +520,7 @@ export class InstrumentationContext {
             const startAt = strLoc[0];
             const endAt = strLoc[0] + strLoc[1];
 
-            let litStr = toUTF8(byteContents.slice(startAt, endAt));
+            let litStr = bytesToString(byteContents.slice(startAt, endAt));
 
             assert(
                 litStr.startsWith("'") || litStr.startsWith('"') || litStr.startsWith("unicode"),
@@ -546,7 +546,7 @@ export class InstrumentationContext {
             utf8enc.encodeInto(litStr, byteContents.subarray(startAt));
         }
 
-        return toUTF8(byteContents);
+        return bytesToString(byteContents);
     }
 
     needsImport(unit: SourceUnit, importPath: string): void {

--- a/src/spec-lang/ast/node.ts
+++ b/src/spec-lang/ast/node.ts
@@ -1,4 +1,4 @@
-import { assert, PPAble, StructEqualityComparable, toUTF8 } from "solc-typed-ast";
+import { assert, PPAble, StructEqualityComparable, bytesToString } from "solc-typed-ast";
 import { Range } from "../../util/location";
 
 let nNodes = 0;
@@ -57,6 +57,6 @@ export abstract class SNode implements StructEqualityComparable, PPAble {
     getSourceFragment(src: Uint8Array): string {
         const rng = this.requiredRange;
 
-        return toUTF8(src.slice(rng.start.offset, rng.end.offset));
+        return bytesToString(src.slice(rng.start.offset, rng.end.offset));
     }
 }

--- a/src/util/json_output.ts
+++ b/src/util/json_output.ts
@@ -10,7 +10,7 @@ import {
     SourceUnit,
     SrcRangeMap,
     StructuredDocumentation,
-    toUTF8,
+    bytesToString,
     VariableDeclaration
 } from "solc-typed-ast";
 import { Range, SrcTriple } from "./location";
@@ -533,7 +533,7 @@ function addSrcToContext(r: CompileResult): any {
     for (const [fileName] of Object.entries(r.data["sources"])) {
         const contentsBuf = r.files.get(fileName);
         r.data["sources"][fileName]["source"] =
-            contentsBuf !== undefined ? toUTF8(contentsBuf) : undefined;
+            contentsBuf !== undefined ? bytesToString(contentsBuf) : undefined;
     }
 
     return r.data["sources"];

--- a/src/util/sources.ts
+++ b/src/util/sources.ts
@@ -1,4 +1,4 @@
-import { toUTF8 } from "solc-typed-ast";
+import { bytesToString } from "solc-typed-ast";
 
 export abstract class SourceFile {
     public readonly contents;
@@ -6,7 +6,7 @@ export abstract class SourceFile {
         public fileName: string,
         public rawContents: Uint8Array
     ) {
-        this.contents = toUTF8(rawContents);
+        this.contents = bytesToString(rawContents);
     }
 }
 

--- a/src/util/unicode.ts
+++ b/src/util/unicode.ts
@@ -3,48 +3,6 @@ export type IdxToOffMap = Map<number, number>;
 const utf8Enc = new TextEncoder();
 const scratch = new Uint8Array(4);
 
-export function strUTF8Len(s: string): number {
-    let len = 0;
-    for (const ch of s) {
-        len += utf8Enc.encodeInto(ch, scratch).written;
-    }
-
-    return len;
-}
-
-/**
- * Get the UTF-8 encoding byte offset of the unicode character at index i in s.
- */
-export function strUTF16IndexToUTF8Offset(s: string, idx: number): number {
-    let i = 0,
-        off = 0;
-
-    for (const ch of s) {
-        if (i === idx) {
-            return off;
-        }
-
-        const charBytes = utf8Enc.encodeInto(ch, scratch).written;
-
-        i += charBytes <= 2 ? 1 : 2;
-        off += charBytes;
-
-        if (i === idx) {
-            return off;
-        }
-
-        if (i >= idx) {
-            throw new Error(`No unicode character index ${idx} in string ${s}.`);
-        }
-    }
-
-    if (i === idx) {
-        return off;
-    }
-
-    throw new Error(`No unicode character index ${idx} in string ${s}.`);
-}
-
 /**
  * Build a map from UTF-16 encoded string indices to their byte offsets in the
  * corresponding UTF-8 encoding.

--- a/test/integration/propertymap.spec.ts
+++ b/test/integration/propertymap.spec.ts
@@ -3,13 +3,13 @@ import fse from "fs-extra";
 import {
     assert,
     ContractDefinition,
-    fromUTF8,
+    stringToBytes,
     FunctionDefinition,
     SourceUnit,
     Statement,
     StatementWithChildren,
     StructuredDocumentation,
-    toUTF8,
+    bytesToString,
     VariableDeclaration
 } from "solc-typed-ast";
 import { getOr, InstrumentationMetaData, searchRecursive } from "../../src/util";
@@ -188,7 +188,7 @@ describe("Property map test", () => {
 
                     const contents = await fse.readFile(fileName);
 
-                    let extracted = toUTF8(contents.slice(start, start + len)).trim();
+                    let extracted = bytesToString(contents.slice(start, start + len)).trim();
 
                     if (extracted.endsWith(";")) {
                         extracted = extracted.slice(0, -1);
@@ -240,8 +240,8 @@ describe("Property map test", () => {
                         expect(fileInd).toBe(0);
                         expect(instrMetadata.instrSourceList[fileInd]).toBe("--");
 
-                        const contents = fromUTF8(outJSON.sources["flattened.sol"]["source"]);
-                        const extracted = toUTF8(contents.slice(start, start + len)).trim();
+                        const contents = stringToBytes(outJSON.sources["flattened.sol"]["source"]);
+                        const extracted = bytesToString(contents.slice(start, start + len)).trim();
 
                         if (extracted === "assert(false)") {
                             continue;

--- a/test/integration/src2srcmap.spec.ts
+++ b/test/integration/src2srcmap.spec.ts
@@ -28,8 +28,8 @@ import {
     UnaryOperation,
     VariableDeclaration,
     FileMap,
-    fromUTF8,
-    toUTF8
+    stringToBytes,
+    bytesToString
 } from "solc-typed-ast";
 import {
     contains,
@@ -89,7 +89,7 @@ function buildSrc2NodeMap(units: SourceUnit[], newSrcList?: string[]): Src2NodeM
 function fragment(src: string, contents: Uint8Array) {
     const [off, len] = parseSrcTriple(src);
 
-    return toUTF8(contents.slice(off, off + len));
+    return bytesToString(contents.slice(off, off + len));
 }
 
 describe("Src2src map test", () => {
@@ -137,7 +137,7 @@ describe("Src2src map test", () => {
                 }
                 outJSON = JSON.parse(scrSample(args[0], ...args.slice(1)));
 
-                instrContents = fromUTF8(outJSON["sources"]["flattened.sol"]["source"]);
+                instrContents = stringToBytes(outJSON["sources"]["flattened.sol"]["source"]);
 
                 const contentsMap: FileMap = new Map([["flattened.sol", instrContents]]);
                 const reader = new ASTReader();

--- a/test/integration/utils.ts
+++ b/test/integration/utils.ts
@@ -16,7 +16,7 @@ import {
     PossibleCompilerKinds,
     SourceUnit,
     Statement,
-    toUTF8,
+    bytesToString,
     VariableDeclaration,
     XPath
 } from "solc-typed-ast";
@@ -71,7 +71,7 @@ export function makeArtefact(result: CompileResult): string {
             delete entry.legacyAST;
         }
 
-        artefact.sources[removeProcWd(name)] = { ...entry, source: toUTF8(source) };
+        artefact.sources[removeProcWd(name)] = { ...entry, source: bytesToString(source) };
     }
 
     return removeProcWd(JSON.stringify(artefact));

--- a/test/unit/interposing.spec.ts
+++ b/test/unit/interposing.spec.ts
@@ -4,7 +4,7 @@ import {
     ASTContext,
     ASTNodeFactory,
     ContractDefinition,
-    fromUTF8,
+    stringToBytes,
     FunctionDefinition,
     SourceUnit,
     TupleExpression,
@@ -31,7 +31,7 @@ function print(units: SourceUnit[], contents: string[], version: string): Map<So
     const contentMap = new Map(
         units.map((unit, idx) => [
             unit.absolutePath,
-            new SolFile(unit.absolutePath, fromUTF8(contents[idx]))
+            new SolFile(unit.absolutePath, stringToBytes(contents[idx]))
         ])
     );
     const context = new ASTContext(...units);

--- a/test/unit/sc.spec.ts
+++ b/test/unit/sc.spec.ts
@@ -3,7 +3,7 @@ import {
     BoolType,
     ContractDefinition,
     eq,
-    fromUTF8,
+    stringToBytes,
     FunctionDefinition,
     InferType,
     IntLiteralType,
@@ -371,7 +371,7 @@ describe("SemanticChecker Expression Unit Tests", () => {
 
                 units = result.units;
                 inference = new InferType(compilerVersion);
-                sourceFile = new SolFile(fileName, fromUTF8(content));
+                sourceFile = new SolFile(fileName, stringToBytes(content));
             });
 
             for (const [specString, loc, expectedType, expectedInfo] of testCases) {
@@ -423,7 +423,7 @@ describe("SemanticChecker Expression Unit Tests", () => {
 
                 units = result.units;
                 inference = new InferType(compilerVersion);
-                sourceFile = new SolFile(fileName, fromUTF8(content));
+                sourceFile = new SolFile(fileName, stringToBytes(content));
             });
 
             for (const [specString, loc] of testCases) {
@@ -539,7 +539,7 @@ describe("SemanticChecker Annotation Unit Tests", () => {
 
                 units = result.units;
                 inference = new InferType(compilerVersion);
-                sourceFile = new SolFile(fileName, fromUTF8(content));
+                sourceFile = new SolFile(fileName, stringToBytes(content));
             });
 
             for (const [specString, loc] of testCases) {
@@ -581,7 +581,7 @@ describe("SemanticChecker Annotation Unit Tests", () => {
 
                 units = result.units;
                 inference = new InferType(compilerVersion);
-                sourceFile = new SolFile(fileName, fromUTF8(content));
+                sourceFile = new SolFile(fileName, stringToBytes(content));
             });
 
             for (const [specString, loc] of testCases) {

--- a/test/unit/tc.spec.ts
+++ b/test/unit/tc.spec.ts
@@ -11,7 +11,7 @@ import {
     EnumDefinition,
     eq,
     FixedBytesType,
-    fromUTF8,
+    stringToBytes,
     FunctionStateMutability,
     FunctionType,
     FunctionVisibility,
@@ -988,7 +988,7 @@ contract UserDefinedValueTypes {
                 compilerVersion = result.compilerVersion;
 
                 inference = new InferType(compilerVersion);
-                sourceFile = new SolFile(fileName, fromUTF8(content));
+                sourceFile = new SolFile(fileName, stringToBytes(content));
             });
 
             for (const [specString, loc, expected] of testCases) {
@@ -1025,7 +1025,7 @@ contract UserDefinedValueTypes {
                 const inference = new InferType(compilerVersion);
 
                 typeEnv = new TypeEnv(inference);
-                sourceFile = new SolFile(fileName, fromUTF8(content));
+                sourceFile = new SolFile(fileName, stringToBytes(content));
             });
 
             for (const [specString, loc] of testCases) {
@@ -1694,7 +1694,7 @@ contract Statements08 {
 
                 inference = new InferType(compilerVersion);
                 typeEnv = new TypeEnv(inference);
-                sourceFile = new SolFile(fileName, fromUTF8(content));
+                sourceFile = new SolFile(fileName, stringToBytes(content));
             });
 
             for (const [specString, loc, expectedType, clearFunsBefore] of testCases) {
@@ -1744,7 +1744,7 @@ contract Statements08 {
                 const inference = new InferType(compilerVersion);
 
                 typeEnv = new TypeEnv(inference);
-                sourceFile = new SolFile(fileName, fromUTF8(content));
+                sourceFile = new SolFile(fileName, stringToBytes(content));
 
                 // Setup any definitions
                 for (const [specString, loc] of setupSteps) {


### PR DESCRIPTION
This PR:
-  bumps solc-typed-ast to 18.1.0
- renames some changed unicode helpers